### PR TITLE
GBE-487: null featureInfoFormat parameter not passed to layer object

### DIFF
--- a/plugin/deskmanager/deskmanager/src/main/java/org/geomajas/plugin/deskmanager/service/manager/DiscoveryServiceImpl.java
+++ b/plugin/deskmanager/deskmanager/src/main/java/org/geomajas/plugin/deskmanager/service/manager/DiscoveryServiceImpl.java
@@ -446,8 +446,12 @@ public class DiscoveryServiceImpl implements DiscoveryService {
 		params.put(WmsLayerBeanFactory.ENABLE_FEATURE_INFO, Boolean.parseBoolean(rlc.getParameterValue(
 				WmsLayerBeanFactory.ENABLE_FEATURE_INFO)));
 
-		params.put(WmsLayerBeanFactory.FEATURE_INFO_FORMAT, WmsLayer.WmsFeatureInfoFormat.parseFormat((String) rlc
-				.getParameterValue(WmsLayerBeanFactory.FEATURE_INFO_FORMAT)));
+		WmsLayer.WmsFeatureInfoFormat wmsFeatureInfoFormat = WmsLayer.WmsFeatureInfoFormat.parseFormat(
+				rlc.getParameterValue(WmsLayerBeanFactory.FEATURE_INFO_FORMAT));
+		if (wmsFeatureInfoFormat != null) {
+			params.put(WmsLayerBeanFactory.FEATURE_INFO_FORMAT, wmsFeatureInfoFormat);
+		}
+
 		//TODO: all these parameters should be configurable too
 		params.put("useProxy", true);
 		params.put("useCache", true);


### PR DESCRIPTION
BUGFIX: if FeatureInforFormat parameter is null, subsequent bean creation will not be finished.
