### PR TITLE
Jv gbe 572 update copyright to2016

### DIFF
--- a/api-experimental/pom.xml
+++ b/api-experimental/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/api-experimental/src/main/java/org/geomajas/configuration/TileCacheConfiguration.java
+++ b/api-experimental/src/main/java/org/geomajas/configuration/TileCacheConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api-experimental/src/main/java/org/geomajas/rendering/GraphicsDocument.java
+++ b/api-experimental/src/main/java/org/geomajas/rendering/GraphicsDocument.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api-experimental/src/main/java/org/geomajas/rendering/RenderException.java
+++ b/api-experimental/src/main/java/org/geomajas/rendering/RenderException.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api-experimental/src/main/java/org/geomajas/rendering/StyleFilter.java
+++ b/api-experimental/src/main/java/org/geomajas/rendering/StyleFilter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api-experimental/src/main/java/org/geomajas/rendering/image/RasterUrlBuilder.java
+++ b/api-experimental/src/main/java/org/geomajas/rendering/image/RasterUrlBuilder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api-experimental/src/main/java/org/geomajas/rendering/painter/StyledLayer.java
+++ b/api-experimental/src/main/java/org/geomajas/rendering/painter/StyledLayer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api-experimental/src/main/java/org/geomajas/rendering/painter/TilePaintContext.java
+++ b/api-experimental/src/main/java/org/geomajas/rendering/painter/TilePaintContext.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api-experimental/src/main/java/org/geomajas/rendering/painter/image/FeatureImagePainter.java
+++ b/api-experimental/src/main/java/org/geomajas/rendering/painter/image/FeatureImagePainter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api-experimental/src/main/java/org/geomajas/rendering/painter/tile/TilePainter.java
+++ b/api-experimental/src/main/java/org/geomajas/rendering/painter/tile/TilePainter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api-experimental/src/main/java/org/geomajas/service/CacheService.java
+++ b/api-experimental/src/main/java/org/geomajas/service/CacheService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/command/Command.java
+++ b/api/src/main/java/org/geomajas/command/Command.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/command/CommandDispatcher.java
+++ b/api/src/main/java/org/geomajas/command/CommandDispatcher.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/command/CommandHasRequest.java
+++ b/api/src/main/java/org/geomajas/command/CommandHasRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/command/CommandRequest.java
+++ b/api/src/main/java/org/geomajas/command/CommandRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/command/CommandResponse.java
+++ b/api/src/main/java/org/geomajas/command/CommandResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/command/EmptyCommandRequest.java
+++ b/api/src/main/java/org/geomajas/command/EmptyCommandRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/command/LayerIdCommandRequest.java
+++ b/api/src/main/java/org/geomajas/command/LayerIdCommandRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/command/LayerIdsCommandRequest.java
+++ b/api/src/main/java/org/geomajas/command/LayerIdsCommandRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/command/SuccessCommandResponse.java
+++ b/api/src/main/java/org/geomajas/command/SuccessCommandResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/AbstractAttributeInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/AbstractAttributeInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/AbstractEditableAttributeInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/AbstractEditableAttributeInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/AbstractReadOnlyAttributeInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/AbstractReadOnlyAttributeInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/AssociationAttributeInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/AssociationAttributeInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/AssociationType.java
+++ b/api/src/main/java/org/geomajas/configuration/AssociationType.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/AttributeBaseInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/AttributeBaseInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/AttributeInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/AttributeInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/CircleInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/CircleInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/EditableAttributeInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/EditableAttributeInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/FeatureInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/FeatureInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/FeatureStyleInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/FeatureStyleInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/FontStyleInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/FontStyleInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/GeometryAttributeInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/GeometryAttributeInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/ImageInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/ImageInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/IsInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/IsInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/LabelStyleInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/LabelStyleInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/LayerExtraInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/LayerExtraInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/LayerInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/LayerInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/NamedStyleInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/NamedStyleInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/Parameter.java
+++ b/api/src/main/java/org/geomajas/configuration/Parameter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/PrimitiveAttributeInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/PrimitiveAttributeInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/PrimitiveType.java
+++ b/api/src/main/java/org/geomajas/configuration/PrimitiveType.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/RasterLayerInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/RasterLayerInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/RectInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/RectInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/ServerSideOnlyInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/ServerSideOnlyInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/SnappingRuleInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/SnappingRuleInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/SortType.java
+++ b/api/src/main/java/org/geomajas/configuration/SortType.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/SymbolInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/SymbolInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/SyntheticAttributeInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/SyntheticAttributeInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/VectorLayerInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/VectorLayerInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/BoundsLimitOption.java
+++ b/api/src/main/java/org/geomajas/configuration/client/BoundsLimitOption.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/ClientApplicationInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/client/ClientApplicationInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/ClientLayerInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/client/ClientLayerInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/ClientLayerTreeInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/client/ClientLayerTreeInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/ClientLayerTreeNodeInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/client/ClientLayerTreeNodeInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/ClientMapInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/client/ClientMapInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/ClientPreferredPixelsPerTile.java
+++ b/api/src/main/java/org/geomajas/configuration/client/ClientPreferredPixelsPerTile.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/ClientRasterLayerInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/client/ClientRasterLayerInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/ClientToolInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/client/ClientToolInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/ClientToolbarInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/client/ClientToolbarInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/ClientUserDataInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/client/ClientUserDataInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/ClientVectorLayerInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/client/ClientVectorLayerInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/ClientWidgetInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/client/ClientWidgetInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/PreferredPixelsPerTileType.java
+++ b/api/src/main/java/org/geomajas/configuration/client/PreferredPixelsPerTileType.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/ScaleConfigurationInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/client/ScaleConfigurationInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/ScaleInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/client/ScaleInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/ScaleUnit.java
+++ b/api/src/main/java/org/geomajas/configuration/client/ScaleUnit.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/client/UnitType.java
+++ b/api/src/main/java/org/geomajas/configuration/client/UnitType.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/validation/AssertFalseConstraintInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/validation/AssertFalseConstraintInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/validation/AssertTrueConstraintInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/validation/AssertTrueConstraintInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/validation/ConstraintInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/validation/ConstraintInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/validation/DecimalMaxConstraintInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/validation/DecimalMaxConstraintInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/validation/DecimalMinConstraintInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/validation/DecimalMinConstraintInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/validation/DigitsConstraintInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/validation/DigitsConstraintInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/validation/FutureConstraintInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/validation/FutureConstraintInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/validation/MaxConstraintInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/validation/MaxConstraintInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/validation/MinConstraintInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/validation/MinConstraintInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/validation/NotNullConstraintInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/validation/NotNullConstraintInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/validation/NullConstraintInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/validation/NullConstraintInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/validation/PastConstraintInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/validation/PastConstraintInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/validation/PatternConstraintInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/validation/PatternConstraintInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/validation/SizeConstraintInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/validation/SizeConstraintInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/configuration/validation/ValidatorInfo.java
+++ b/api/src/main/java/org/geomajas/configuration/validation/ValidatorInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/geometry/Crs.java
+++ b/api/src/main/java/org/geomajas/geometry/Crs.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/geometry/CrsTransform.java
+++ b/api/src/main/java/org/geomajas/geometry/CrsTransform.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/global/Api.java
+++ b/api/src/main/java/org/geomajas/global/Api.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/global/CacheableObject.java
+++ b/api/src/main/java/org/geomajas/global/CacheableObject.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/global/CopyrightInfo.java
+++ b/api/src/main/java/org/geomajas/global/CopyrightInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/global/CrsInfo.java
+++ b/api/src/main/java/org/geomajas/global/CrsInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/global/CrsTransformInfo.java
+++ b/api/src/main/java/org/geomajas/global/CrsTransformInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/global/ExceptionCode.java
+++ b/api/src/main/java/org/geomajas/global/ExceptionCode.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/global/ExceptionDto.java
+++ b/api/src/main/java/org/geomajas/global/ExceptionDto.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/global/ExpectAlternatives.java
+++ b/api/src/main/java/org/geomajas/global/ExpectAlternatives.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/global/FutureApi.java
+++ b/api/src/main/java/org/geomajas/global/FutureApi.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/global/GeomajasConstant.java
+++ b/api/src/main/java/org/geomajas/global/GeomajasConstant.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/global/GeomajasException.java
+++ b/api/src/main/java/org/geomajas/global/GeomajasException.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/global/Json.java
+++ b/api/src/main/java/org/geomajas/global/Json.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/global/PluginInfo.java
+++ b/api/src/main/java/org/geomajas/global/PluginInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/global/PluginVersionInfo.java
+++ b/api/src/main/java/org/geomajas/global/PluginVersionInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/global/ResolutionFormat.java
+++ b/api/src/main/java/org/geomajas/global/ResolutionFormat.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/global/UserImplemented.java
+++ b/api/src/main/java/org/geomajas/global/UserImplemented.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/Layer.java
+++ b/api/src/main/java/org/geomajas/layer/Layer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/LayerException.java
+++ b/api/src/main/java/org/geomajas/layer/LayerException.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/LayerService.java
+++ b/api/src/main/java/org/geomajas/layer/LayerService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/LayerType.java
+++ b/api/src/main/java/org/geomajas/layer/LayerType.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/RasterLayer.java
+++ b/api/src/main/java/org/geomajas/layer/RasterLayer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/RasterLayerService.java
+++ b/api/src/main/java/org/geomajas/layer/RasterLayerService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/VectorLayer.java
+++ b/api/src/main/java/org/geomajas/layer/VectorLayer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/VectorLayerAssociationSupport.java
+++ b/api/src/main/java/org/geomajas/layer/VectorLayerAssociationSupport.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/VectorLayerLazyFeatureConversionSupport.java
+++ b/api/src/main/java/org/geomajas/layer/VectorLayerLazyFeatureConversionSupport.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/VectorLayerService.java
+++ b/api/src/main/java/org/geomajas/layer/VectorLayerService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/entity/Entity.java
+++ b/api/src/main/java/org/geomajas/layer/entity/Entity.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/entity/EntityAttributeService.java
+++ b/api/src/main/java/org/geomajas/layer/entity/EntityAttributeService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/entity/EntityCollection.java
+++ b/api/src/main/java/org/geomajas/layer/entity/EntityCollection.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/entity/EntityMapper.java
+++ b/api/src/main/java/org/geomajas/layer/entity/EntityMapper.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/Attribute.java
+++ b/api/src/main/java/org/geomajas/layer/feature/Attribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/Feature.java
+++ b/api/src/main/java/org/geomajas/layer/feature/Feature.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/FeatureModel.java
+++ b/api/src/main/java/org/geomajas/layer/feature/FeatureModel.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/FeatureTransaction.java
+++ b/api/src/main/java/org/geomajas/layer/feature/FeatureTransaction.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/InternalFeature.java
+++ b/api/src/main/java/org/geomajas/layer/feature/InternalFeature.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/SearchCriterion.java
+++ b/api/src/main/java/org/geomajas/layer/feature/SearchCriterion.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/SyntheticAttributeBuilder.java
+++ b/api/src/main/java/org/geomajas/layer/feature/SyntheticAttributeBuilder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/attribute/ArrayAttribute.java
+++ b/api/src/main/java/org/geomajas/layer/feature/attribute/ArrayAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/attribute/AssociationAttribute.java
+++ b/api/src/main/java/org/geomajas/layer/feature/attribute/AssociationAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/attribute/AssociationValue.java
+++ b/api/src/main/java/org/geomajas/layer/feature/attribute/AssociationValue.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/attribute/BooleanAttribute.java
+++ b/api/src/main/java/org/geomajas/layer/feature/attribute/BooleanAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/attribute/CurrencyAttribute.java
+++ b/api/src/main/java/org/geomajas/layer/feature/attribute/CurrencyAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/attribute/DateAttribute.java
+++ b/api/src/main/java/org/geomajas/layer/feature/attribute/DateAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/attribute/DoubleAttribute.java
+++ b/api/src/main/java/org/geomajas/layer/feature/attribute/DoubleAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/attribute/FloatAttribute.java
+++ b/api/src/main/java/org/geomajas/layer/feature/attribute/FloatAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/attribute/ImageUrlAttribute.java
+++ b/api/src/main/java/org/geomajas/layer/feature/attribute/ImageUrlAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/attribute/IntegerAttribute.java
+++ b/api/src/main/java/org/geomajas/layer/feature/attribute/IntegerAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/attribute/LongAttribute.java
+++ b/api/src/main/java/org/geomajas/layer/feature/attribute/LongAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/attribute/ManyToOneAttribute.java
+++ b/api/src/main/java/org/geomajas/layer/feature/attribute/ManyToOneAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/attribute/OneToManyAttribute.java
+++ b/api/src/main/java/org/geomajas/layer/feature/attribute/OneToManyAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/attribute/PrimitiveAttribute.java
+++ b/api/src/main/java/org/geomajas/layer/feature/attribute/PrimitiveAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/attribute/ShortAttribute.java
+++ b/api/src/main/java/org/geomajas/layer/feature/attribute/ShortAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/attribute/StringAttribute.java
+++ b/api/src/main/java/org/geomajas/layer/feature/attribute/StringAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/feature/attribute/UrlAttribute.java
+++ b/api/src/main/java/org/geomajas/layer/feature/attribute/UrlAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/pipeline/GetAttributesContainer.java
+++ b/api/src/main/java/org/geomajas/layer/pipeline/GetAttributesContainer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/pipeline/GetBoundsContainer.java
+++ b/api/src/main/java/org/geomajas/layer/pipeline/GetBoundsContainer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/pipeline/GetFeaturesContainer.java
+++ b/api/src/main/java/org/geomajas/layer/pipeline/GetFeaturesContainer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/pipeline/GetTileContainer.java
+++ b/api/src/main/java/org/geomajas/layer/pipeline/GetTileContainer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/tile/InternalTile.java
+++ b/api/src/main/java/org/geomajas/layer/tile/InternalTile.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/tile/RasterTile.java
+++ b/api/src/main/java/org/geomajas/layer/tile/RasterTile.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/tile/TileCode.java
+++ b/api/src/main/java/org/geomajas/layer/tile/TileCode.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/tile/TileMetadata.java
+++ b/api/src/main/java/org/geomajas/layer/tile/TileMetadata.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/layer/tile/VectorTile.java
+++ b/api/src/main/java/org/geomajas/layer/tile/VectorTile.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/security/AreaAuthorization.java
+++ b/api/src/main/java/org/geomajas/security/AreaAuthorization.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/security/AttributeAuthorization.java
+++ b/api/src/main/java/org/geomajas/security/AttributeAuthorization.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/security/Authentication.java
+++ b/api/src/main/java/org/geomajas/security/Authentication.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/security/AuthenticationCache.java
+++ b/api/src/main/java/org/geomajas/security/AuthenticationCache.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/security/Authorization.java
+++ b/api/src/main/java/org/geomajas/security/Authorization.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/security/AuthorizationNeedsWiring.java
+++ b/api/src/main/java/org/geomajas/security/AuthorizationNeedsWiring.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/security/BaseAuthorization.java
+++ b/api/src/main/java/org/geomajas/security/BaseAuthorization.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/security/FeatureAuthorization.java
+++ b/api/src/main/java/org/geomajas/security/FeatureAuthorization.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/security/GeomajasSecurityException.java
+++ b/api/src/main/java/org/geomajas/security/GeomajasSecurityException.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/security/SavedAuthentication.java
+++ b/api/src/main/java/org/geomajas/security/SavedAuthentication.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/security/SavedAuthorization.java
+++ b/api/src/main/java/org/geomajas/security/SavedAuthorization.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/security/SecurityContext.java
+++ b/api/src/main/java/org/geomajas/security/SecurityContext.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/security/SecurityInfo.java
+++ b/api/src/main/java/org/geomajas/security/SecurityInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/security/SecurityManager.java
+++ b/api/src/main/java/org/geomajas/security/SecurityManager.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/security/SecurityService.java
+++ b/api/src/main/java/org/geomajas/security/SecurityService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/security/UserInfo.java
+++ b/api/src/main/java/org/geomajas/security/UserInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/security/VectorLayerSelectFilterAuthorization.java
+++ b/api/src/main/java/org/geomajas/security/VectorLayerSelectFilterAuthorization.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/BeanNameSimplifier.java
+++ b/api/src/main/java/org/geomajas/service/BeanNameSimplifier.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/ConfigurationService.java
+++ b/api/src/main/java/org/geomajas/service/ConfigurationService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/DispatcherUrlService.java
+++ b/api/src/main/java/org/geomajas/service/DispatcherUrlService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/DtoConverterService.java
+++ b/api/src/main/java/org/geomajas/service/DtoConverterService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/FeatureExpressionService.java
+++ b/api/src/main/java/org/geomajas/service/FeatureExpressionService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/FilterService.java
+++ b/api/src/main/java/org/geomajas/service/FilterService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/GeoService.java
+++ b/api/src/main/java/org/geomajas/service/GeoService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/LayerInvalidationService.java
+++ b/api/src/main/java/org/geomajas/service/LayerInvalidationService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/LegendGraphicService.java
+++ b/api/src/main/java/org/geomajas/service/LegendGraphicService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/ResourceService.java
+++ b/api/src/main/java/org/geomajas/service/ResourceService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/StyleConverterService.java
+++ b/api/src/main/java/org/geomajas/service/StyleConverterService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/StyleService.java
+++ b/api/src/main/java/org/geomajas/service/StyleService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/TestRecorder.java
+++ b/api/src/main/java/org/geomajas/service/TestRecorder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/TextService.java
+++ b/api/src/main/java/org/geomajas/service/TextService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/legend/DefaultLegendGraphicMetadata.java
+++ b/api/src/main/java/org/geomajas/service/legend/DefaultLegendGraphicMetadata.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/legend/LegendGraphicMetadata.java
+++ b/api/src/main/java/org/geomajas/service/legend/LegendGraphicMetadata.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/pipeline/AbstractPipelineInterceptor.java
+++ b/api/src/main/java/org/geomajas/service/pipeline/AbstractPipelineInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/pipeline/PipelineCode.java
+++ b/api/src/main/java/org/geomajas/service/pipeline/PipelineCode.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/pipeline/PipelineContext.java
+++ b/api/src/main/java/org/geomajas/service/pipeline/PipelineContext.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/pipeline/PipelineHook.java
+++ b/api/src/main/java/org/geomajas/service/pipeline/PipelineHook.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/pipeline/PipelineInfo.java
+++ b/api/src/main/java/org/geomajas/service/pipeline/PipelineInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/pipeline/PipelineInterceptor.java
+++ b/api/src/main/java/org/geomajas/service/pipeline/PipelineInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/pipeline/PipelineService.java
+++ b/api/src/main/java/org/geomajas/service/pipeline/PipelineService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/pipeline/PipelineStep.java
+++ b/api/src/main/java/org/geomajas/service/pipeline/PipelineStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/pipeline/SkipStepPipelineInterceptor.java
+++ b/api/src/main/java/org/geomajas/service/pipeline/SkipStepPipelineInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/service/resource/ResourceInfo.java
+++ b/api/src/main/java/org/geomajas/service/resource/ResourceInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/java/org/geomajas/spring/ReconfigurableApplicationContext.java
+++ b/api/src/main/java/org/geomajas/spring/ReconfigurableApplicationContext.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/main/resources/org/geomajas/global/GeomajasException_en.properties
+++ b/api/src/main/resources/org/geomajas/global/GeomajasException_en.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/api/src/main/resources/org/geomajas/global/GeomajasException_nl.properties
+++ b/api/src/main/resources/org/geomajas/global/GeomajasException_nl.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/api/src/main/resources/org/geomajas/global/GeomajasException_pt.properties
+++ b/api/src/main/resources/org/geomajas/global/GeomajasException_pt.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/api/src/test/java/org/geomajas/configuration/client/ClientToolInfoTest.java
+++ b/api/src/test/java/org/geomajas/configuration/client/ClientToolInfoTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/test/java/org/geomajas/configuration/client/ScaleInfoTest.java
+++ b/api/src/test/java/org/geomajas/configuration/client/ScaleInfoTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/test/java/org/geomajas/global/GeomajasExceptionTest.java
+++ b/api/src/test/java/org/geomajas/global/GeomajasExceptionTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/test/java/org/geomajas/json/AnnotationTest.java
+++ b/api/src/test/java/org/geomajas/json/AnnotationTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/test/java/org/geomajas/layer/feature/attribute/AttributeCloneTest.java
+++ b/api/src/test/java/org/geomajas/layer/feature/attribute/AttributeCloneTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/api/src/test/resources/logback-test.xml
+++ b/api/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/api/src/test/resources/org/geomajas/global/GeomajasExceptionTest.properties
+++ b/api/src/test/resources/org/geomajas/global/GeomajasExceptionTest.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/command/pom.xml
+++ b/command/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/configuration/GetConfigurationCommand.java
+++ b/command/src/main/java/org/geomajas/command/configuration/GetConfigurationCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/configuration/GetMapConfigurationCommand.java
+++ b/command/src/main/java/org/geomajas/command/configuration/GetMapConfigurationCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/configuration/RefreshConfigurationCommand.java
+++ b/command/src/main/java/org/geomajas/command/configuration/RefreshConfigurationCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/configuration/UserMaximumExtentCommand.java
+++ b/command/src/main/java/org/geomajas/command/configuration/UserMaximumExtentCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/BufferInfo.java
+++ b/command/src/main/java/org/geomajas/command/dto/BufferInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/CopyrightRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/CopyrightRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/CopyrightResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/CopyrightResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GeometryAreaRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/GeometryAreaRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GeometryAreaResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/GeometryAreaResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GeometryBufferRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/GeometryBufferRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GeometryBufferResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/GeometryBufferResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GeometryConvexHullRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/GeometryConvexHullRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GeometryConvexHullResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/GeometryConvexHullResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GeometryMergeRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/GeometryMergeRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GeometryMergeResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/GeometryMergeResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GeometrySplitRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/GeometrySplitRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GeometrySplitResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/GeometrySplitResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GetConfigurationRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/GetConfigurationRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GetConfigurationResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/GetConfigurationResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GetMapConfigurationRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/GetMapConfigurationRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GetMapConfigurationResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/GetMapConfigurationResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GetRasterTilesRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/GetRasterTilesRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GetRasterTilesResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/GetRasterTilesResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GetVectorTileRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/GetVectorTileRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/GetVectorTileResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/GetVectorTileResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/LayerFilterSpecification.java
+++ b/command/src/main/java/org/geomajas/command/dto/LayerFilterSpecification.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/LogRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/LogRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/MergePolygonRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/MergePolygonRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/MergePolygonResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/MergePolygonResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/PersistTransactionRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/PersistTransactionRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/PersistTransactionResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/PersistTransactionResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/RefreshConfigurationRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/RefreshConfigurationRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/RefreshConfigurationResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/RefreshConfigurationResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/RegisterNamedStyleInfoRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/RegisterNamedStyleInfoRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/RegisterNamedStyleInfoResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/RegisterNamedStyleInfoResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/SearchAttributesRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/SearchAttributesRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/SearchAttributesResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/SearchAttributesResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/SearchByLocationRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/SearchByLocationRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/SearchByLocationResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/SearchByLocationResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/SearchFeatureRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/SearchFeatureRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/SearchFeatureResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/SearchFeatureResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/SplitPolygonRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/SplitPolygonRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/SplitPolygonResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/SplitPolygonResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/TransformGeometryRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/TransformGeometryRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/TransformGeometryResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/TransformGeometryResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/UnionInfo.java
+++ b/command/src/main/java/org/geomajas/command/dto/UnionInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/UserMaximumExtentRequest.java
+++ b/command/src/main/java/org/geomajas/command/dto/UserMaximumExtentRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/dto/UserMaximumExtentResponse.java
+++ b/command/src/main/java/org/geomajas/command/dto/UserMaximumExtentResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/feature/PersistTransactionCommand.java
+++ b/command/src/main/java/org/geomajas/command/feature/PersistTransactionCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/feature/SearchAttributesCommand.java
+++ b/command/src/main/java/org/geomajas/command/feature/SearchAttributesCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/feature/SearchByLocationCommand.java
+++ b/command/src/main/java/org/geomajas/command/feature/SearchByLocationCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/feature/SearchFeatureCommand.java
+++ b/command/src/main/java/org/geomajas/command/feature/SearchFeatureCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/general/CopyrightCommand.java
+++ b/command/src/main/java/org/geomajas/command/general/CopyrightCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/general/LogCommand.java
+++ b/command/src/main/java/org/geomajas/command/general/LogCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/geometry/GeometryAreaCommand.java
+++ b/command/src/main/java/org/geomajas/command/geometry/GeometryAreaCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/geometry/GeometryBufferCommand.java
+++ b/command/src/main/java/org/geomajas/command/geometry/GeometryBufferCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/geometry/GeometryConvexHullCommand.java
+++ b/command/src/main/java/org/geomajas/command/geometry/GeometryConvexHullCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/geometry/GeometryMergeCommand.java
+++ b/command/src/main/java/org/geomajas/command/geometry/GeometryMergeCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/geometry/GeometrySplitCommand.java
+++ b/command/src/main/java/org/geomajas/command/geometry/GeometrySplitCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/geometry/MergePolygonCommand.java
+++ b/command/src/main/java/org/geomajas/command/geometry/MergePolygonCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/geometry/SplitPolygonCommand.java
+++ b/command/src/main/java/org/geomajas/command/geometry/SplitPolygonCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/geometry/TransformGeometryCommand.java
+++ b/command/src/main/java/org/geomajas/command/geometry/TransformGeometryCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/render/GetRasterTilesCommand.java
+++ b/command/src/main/java/org/geomajas/command/render/GetRasterTilesCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/render/GetVectorTileCommand.java
+++ b/command/src/main/java/org/geomajas/command/render/GetVectorTileCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/main/java/org/geomajas/command/render/RegisterNamedStyleInfoCommand.java
+++ b/command/src/main/java/org/geomajas/command/render/RegisterNamedStyleInfoCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/com/my/program/command/dto/MySuperDoItRequest.java
+++ b/command/src/test/java/com/my/program/command/dto/MySuperDoItRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/com/my/program/command/dto/MySuperDoItResponse.java
+++ b/command/src/test/java/com/my/program/command/dto/MySuperDoItResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/com/my/program/command/mysuper/MySuperDoItCommand.java
+++ b/command/src/test/java/com/my/program/command/mysuper/MySuperDoItCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/configuration/DummyServerSideOnlyInfo.java
+++ b/command/src/test/java/org/geomajas/command/configuration/DummyServerSideOnlyInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/configuration/GetConfigurationCommandTest.java
+++ b/command/src/test/java/org/geomajas/command/configuration/GetConfigurationCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/configuration/GetMapConfigurationCommandTest.java
+++ b/command/src/test/java/org/geomajas/command/configuration/GetMapConfigurationCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/configuration/RefreshConfigurationCommandTest.java
+++ b/command/src/test/java/org/geomajas/command/configuration/RefreshConfigurationCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/configuration/RefreshTestRecorder.java
+++ b/command/src/test/java/org/geomajas/command/configuration/RefreshTestRecorder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/configuration/UserMaximumExtentCommandTest.java
+++ b/command/src/test/java/org/geomajas/command/configuration/UserMaximumExtentCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/dto/GetVectorTileRequestTest.java
+++ b/command/src/test/java/org/geomajas/command/dto/GetVectorTileRequestTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/feature/PersistTransactionCommandEmptyGeometryTest.java
+++ b/command/src/test/java/org/geomajas/command/feature/PersistTransactionCommandEmptyGeometryTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/feature/PersistTransactionCommandTest.java
+++ b/command/src/test/java/org/geomajas/command/feature/PersistTransactionCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/feature/SearchAttributesCommandTest.java
+++ b/command/src/test/java/org/geomajas/command/feature/SearchAttributesCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/feature/SearchByLocationCommandTest.java
+++ b/command/src/test/java/org/geomajas/command/feature/SearchByLocationCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/feature/SearchFeatureCommandTest.java
+++ b/command/src/test/java/org/geomajas/command/feature/SearchFeatureCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/general/CopyrightCommandTest.java
+++ b/command/src/test/java/org/geomajas/command/general/CopyrightCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/general/LogCommandTest.java
+++ b/command/src/test/java/org/geomajas/command/general/LogCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/geometry/MergePolygonCommandTest.java
+++ b/command/src/test/java/org/geomajas/command/geometry/MergePolygonCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/geometry/SplitPolygonCommandTest.java
+++ b/command/src/test/java/org/geomajas/command/geometry/SplitPolygonCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/render/GetRasterTilesCommandTest.java
+++ b/command/src/test/java/org/geomajas/command/render/GetRasterTilesCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/render/GetVectorTileCommandTest.java
+++ b/command/src/test/java/org/geomajas/command/render/GetVectorTileCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/java/org/geomajas/command/render/RegisterNamedStyleInfoCommandTest.java
+++ b/command/src/test/java/org/geomajas/command/render/RegisterNamedStyleInfoCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/command/src/test/resources/logback-test.xml
+++ b/command/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/command/src/test/resources/org/geomajas/command/ServerSideOnlyConfiguration.xml
+++ b/command/src/test/resources/org/geomajas/command/ServerSideOnlyConfiguration.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/command/src/test/resources/org/geomajas/command/emptyGeometryTest.xml
+++ b/command/src/test/resources/org/geomajas/command/emptyGeometryTest.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/common-servlet/pom.xml
+++ b/common-servlet/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/java/org/geomajas/servlet/ApplicationContextUtil.java
+++ b/common-servlet/src/main/java/org/geomajas/servlet/ApplicationContextUtil.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/java/org/geomajas/servlet/AutomaticDispatcherUrlService.java
+++ b/common-servlet/src/main/java/org/geomajas/servlet/AutomaticDispatcherUrlService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/java/org/geomajas/servlet/CacheFilter.java
+++ b/common-servlet/src/main/java/org/geomajas/servlet/CacheFilter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/java/org/geomajas/servlet/ExtendedJettyClassLoader.java
+++ b/common-servlet/src/main/java/org/geomajas/servlet/ExtendedJettyClassLoader.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/java/org/geomajas/servlet/GeomajasContextListener.java
+++ b/common-servlet/src/main/java/org/geomajas/servlet/GeomajasContextListener.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/java/org/geomajas/servlet/GzipResponseStream.java
+++ b/common-servlet/src/main/java/org/geomajas/servlet/GzipResponseStream.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/java/org/geomajas/servlet/JettyThreadParentFilter.java
+++ b/common-servlet/src/main/java/org/geomajas/servlet/JettyThreadParentFilter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/java/org/geomajas/servlet/NotFoundFilter.java
+++ b/common-servlet/src/main/java/org/geomajas/servlet/NotFoundFilter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/java/org/geomajas/servlet/PrepareScanningContextListener.java
+++ b/common-servlet/src/main/java/org/geomajas/servlet/PrepareScanningContextListener.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/java/org/geomajas/servlet/ResourceController.java
+++ b/common-servlet/src/main/java/org/geomajas/servlet/ResourceController.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/java/org/geomajas/servlet/ResourceServlet.java
+++ b/common-servlet/src/main/java/org/geomajas/servlet/ResourceServlet.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/java/org/geomajas/servlet/mvc/SecurityInterceptor.java
+++ b/common-servlet/src/main/java/org/geomajas/servlet/mvc/SecurityInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/java/org/geomajas/servlet/mvc/TransactionalInterceptor.java
+++ b/common-servlet/src/main/java/org/geomajas/servlet/mvc/TransactionalInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/java/org/geomajas/servlet/mvc/legend/LegendGraphicController.java
+++ b/common-servlet/src/main/java/org/geomajas/servlet/mvc/legend/LegendGraphicController.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/java/org/geomajas/servlet/mvc/legend/LegendGraphicView.java
+++ b/common-servlet/src/main/java/org/geomajas/servlet/mvc/legend/LegendGraphicView.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/java/org/geomajas/spring/LoggingApplicationContext.java
+++ b/common-servlet/src/main/java/org/geomajas/spring/LoggingApplicationContext.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/java/org/geomajas/spring/ReconfigurableClassPathApplicationContext.java
+++ b/common-servlet/src/main/java/org/geomajas/spring/ReconfigurableClassPathApplicationContext.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/main/resources/META-INF/geomajasWebContextCommonServlet.xml
+++ b/common-servlet/src/main/resources/META-INF/geomajasWebContextCommonServlet.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/common-servlet/src/test/java/org/geomajas/servlet/AutomaticDispatcherUrlServiceTest.java
+++ b/common-servlet/src/test/java/org/geomajas/servlet/AutomaticDispatcherUrlServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/test/java/org/geomajas/servlet/CacheFilterTest.java
+++ b/common-servlet/src/test/java/org/geomajas/servlet/CacheFilterTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/common-servlet/src/test/resources/logback-test.xml
+++ b/common-servlet/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 
 	<groupId>org.geomajas.documentation</groupId>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/documentation/src/docbkx/master.xml
+++ b/documentation/src/docbkx/master.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/documentation/src/docbkx/master.xml
+++ b/documentation/src/docbkx/master.xml
@@ -17,7 +17,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2010-2015</year>
+			<year>2010-2016</year>
 
 			<holder>Geosparc nv</holder>
 		</copyright>

--- a/documentation/src/docbkx/part-api.xml
+++ b/documentation/src/docbkx/part-api.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/documentation/src/docbkx/part-appendix.xml
+++ b/documentation/src/docbkx/part-appendix.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/documentation/src/docbkx/part-architecture.xml
+++ b/documentation/src/docbkx/part-architecture.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/documentation/src/docbkx/part-configuration.xml
+++ b/documentation/src/docbkx/part-configuration.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/documentation/src/docbkx/part-howto.xml
+++ b/documentation/src/docbkx/part-howto.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/documentation/src/docbkx/part-introduction.xml
+++ b/documentation/src/docbkx/part-introduction.xml
@@ -77,7 +77,7 @@
     <section id="section-license">
       <title>License information</title>
 
-      <para>Copyright © 2009-2015 Geosparc nv.</para>
+      <para>Copyright © 2009-2016 Geosparc nv.</para>
 
       <para>Licensed under the GNU Affero General Public License. You may
       obtain a copy of the License at <ulink

--- a/documentation/src/docbkx/part-introduction.xml
+++ b/documentation/src/docbkx/part-introduction.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/configuration/ConfigurationDtoPostProcessor.java
+++ b/impl/src/main/java/org/geomajas/internal/configuration/ConfigurationDtoPostProcessor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/configuration/GeotoolsInitializer.java
+++ b/impl/src/main/java/org/geomajas/internal/configuration/GeotoolsInitializer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/configuration/NamingBeanPostProcessor.java
+++ b/impl/src/main/java/org/geomajas/internal/configuration/NamingBeanPostProcessor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/configuration/ScaleInfoEditor.java
+++ b/impl/src/main/java/org/geomajas/internal/configuration/ScaleInfoEditor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/configuration/ScaleInfoEditorRegistrar.java
+++ b/impl/src/main/java/org/geomajas/internal/configuration/ScaleInfoEditorRegistrar.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/configuration/Slf4jLogger.java
+++ b/impl/src/main/java/org/geomajas/internal/configuration/Slf4jLogger.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/configuration/Slf4jLoggerFactory.java
+++ b/impl/src/main/java/org/geomajas/internal/configuration/Slf4jLoggerFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/filter/FeatureModelPropertyAccessorFactory.java
+++ b/impl/src/main/java/org/geomajas/internal/filter/FeatureModelPropertyAccessorFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/filter/InternalFeaturePropertyAccessorFactory.java
+++ b/impl/src/main/java/org/geomajas/internal/filter/InternalFeaturePropertyAccessorFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/filter/NonLenientFilterFactoryImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/filter/NonLenientFilterFactoryImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/LayerServiceImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/LayerServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/RasterLayerServiceImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/RasterLayerServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/VectorLayerServiceImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/VectorLayerServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/entity/EntityAttributeServiceImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/entity/EntityAttributeServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/feature/AttributeService.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/feature/AttributeService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/feature/FeatureModelRegistry.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/feature/FeatureModelRegistry.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/feature/InternalFeatureImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/feature/InternalFeatureImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/feature/InternalFeaturePropertyAccessor.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/feature/InternalFeaturePropertyAccessor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/raster/GetTilesGetStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/raster/GetTilesGetStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/raster/SortTilesStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/raster/SortTilesStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/tile/InternalTileImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/tile/InternalTileImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/tile/TileCodeComparator.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/tile/TileCodeComparator.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/tile/TileMetadataImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/tile/TileMetadataImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/AbstractSaveOrUpdateStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/AbstractSaveOrUpdateStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/FeatureBackTransformGeometryStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/FeatureBackTransformGeometryStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/FeatureListEqualSizeStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/FeatureListEqualSizeStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/FeatureTransformGeometryStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/FeatureTransformGeometryStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/GetAttributesStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/GetAttributesStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/GetBoundsStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/GetBoundsStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/GetFeaturesEachStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/GetFeaturesEachStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/GetFeaturesStyleStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/GetFeaturesStyleStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/GetTileFillStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/GetTileFillStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/GetTileFilterStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/GetTileFilterStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/GetTileGetFeaturesStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/GetTileGetFeaturesStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/GetTileStringContentStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/GetTileStringContentStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/GetTileTransformStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/GetTileTransformStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/LayerFilterStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/LayerFilterStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/SaveOrUpdateCheckIdStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/SaveOrUpdateCheckIdStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/SaveOrUpdateCreateStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/SaveOrUpdateCreateStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/SaveOrUpdateDeleteStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/SaveOrUpdateDeleteStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/SaveOrUpdateEachStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/SaveOrUpdateEachStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/SaveOrUpdateSaveStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/SaveOrUpdateSaveStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/SaveOrUpdateUpdateStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/SaveOrUpdateUpdateStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/UpdateFeatureStep.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/UpdateFeatureStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/lazy/LazyAttribute.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/lazy/LazyAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/lazy/LazyManyToOneAttribute.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/lazy/LazyManyToOneAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/lazy/LazyOneToManyAttribute.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/lazy/LazyOneToManyAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/layer/vector/lazy/LazyPrimitiveAttribute.java
+++ b/impl/src/main/java/org/geomajas/internal/layer/vector/lazy/LazyPrimitiveAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/AbstractGraphicsDocument.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/AbstractGraphicsDocument.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/DefaultSvgDocument.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/DefaultSvgDocument.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/DefaultVmlDocument.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/DefaultVmlDocument.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/StyleFilterImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/StyleFilterImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/painter/tile/StringContentTilePainter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/painter/tile/StringContentTilePainter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/painter/tile/UrlContentTilePainter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/painter/tile/UrlContentTilePainter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/strategy/TileUtil.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/strategy/TileUtil.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/strategy/TiledFeatureService.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/strategy/TiledFeatureService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/GraphicsWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/GraphicsWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/SvgFeatureWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/SvgFeatureWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/SvgLabelTileWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/SvgLabelTileWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/SvgTileWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/SvgTileWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/geometry/BboxWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/geometry/BboxWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/geometry/GeometryCollectionWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/geometry/GeometryCollectionWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/geometry/LineStringWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/geometry/LineStringWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/geometry/MultiLineStringWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/geometry/MultiLineStringWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/geometry/MultiPointWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/geometry/MultiPointWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/geometry/MultiPolygonWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/geometry/MultiPolygonWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/geometry/PointWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/geometry/PointWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/geometry/PolygonWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/svg/geometry/PolygonWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/VmlFeatureWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/VmlFeatureWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/VmlLabelTileWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/VmlLabelTileWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/VmlTileWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/VmlTileWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/geometry/GeometryCollectionWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/geometry/GeometryCollectionWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/geometry/LineStringWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/geometry/LineStringWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/geometry/MultiLineStringWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/geometry/MultiLineStringWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/geometry/MultiPointWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/geometry/MultiPointWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/geometry/MultiPolygonWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/geometry/MultiPolygonWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/geometry/PointWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/geometry/PointWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/geometry/PolygonWriter.java
+++ b/impl/src/main/java/org/geomajas/internal/rendering/writer/vml/geometry/PolygonWriter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/security/DefaultSecurityContext.java
+++ b/impl/src/main/java/org/geomajas/internal/security/DefaultSecurityContext.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/security/DefaultSecurityManager.java
+++ b/impl/src/main/java/org/geomajas/internal/security/DefaultSecurityManager.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/security/EmptySecurityInfo.java
+++ b/impl/src/main/java/org/geomajas/internal/security/EmptySecurityInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/security/SavedAuthenticationImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/security/SavedAuthenticationImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/security/SavedAuthorizationImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/security/SavedAuthorizationImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/CommandDispatcherImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/CommandDispatcherImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/ConfigurationServiceImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/ConfigurationServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/CrsTransformImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/CrsTransformImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/DefaultCacheService.java
+++ b/impl/src/main/java/org/geomajas/internal/service/DefaultCacheService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/DtoConverterServiceImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/DtoConverterServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/DummyTestRecorder.java
+++ b/impl/src/main/java/org/geomajas/internal/service/DummyTestRecorder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/FeatureExpressionServiceImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/FeatureExpressionServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/FilterServiceImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/FilterServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/GeoServiceImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/GeoServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/LegendGraphicServiceImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/LegendGraphicServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/RealTestRecorder.java
+++ b/impl/src/main/java/org/geomajas/internal/service/RealTestRecorder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/ResourceServiceImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/ResourceServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/StyleConverterServiceImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/StyleConverterServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/StyleServiceImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/StyleServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/TextServiceImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/TextServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/crs/CompoundCrsImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/crs/CompoundCrsImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/crs/CrsFactory.java
+++ b/impl/src/main/java/org/geomajas/internal/service/crs/CrsFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/crs/CrsImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/crs/CrsImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/crs/GeneralDerivedCrsImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/crs/GeneralDerivedCrsImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/crs/GeodeticCrsImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/crs/GeodeticCrsImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/crs/GeographicCrsImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/crs/GeographicCrsImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/crs/ProjectedCrsImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/crs/ProjectedCrsImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/crs/SingleCrsImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/crs/SingleCrsImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/crs/TemporalCrsImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/crs/TemporalCrsImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/pipeline/PipelineContextImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/pipeline/PipelineContextImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/service/pipeline/PipelineServiceImpl.java
+++ b/impl/src/main/java/org/geomajas/internal/service/pipeline/PipelineServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/internal/util/WebSafeStringEncoder.java
+++ b/impl/src/main/java/org/geomajas/internal/util/WebSafeStringEncoder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/layer/bean/BeanEntityMapper.java
+++ b/impl/src/main/java/org/geomajas/layer/bean/BeanEntityMapper.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/layer/bean/BeanFeatureModel.java
+++ b/impl/src/main/java/org/geomajas/layer/bean/BeanFeatureModel.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/layer/bean/BeanLayer.java
+++ b/impl/src/main/java/org/geomajas/layer/bean/BeanLayer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/layer/bean/FeatureBean.java
+++ b/impl/src/main/java/org/geomajas/layer/bean/FeatureBean.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/layer/bean/FeatureModelAware.java
+++ b/impl/src/main/java/org/geomajas/layer/bean/FeatureModelAware.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/layer/bean/ManyToOneAttributeBean.java
+++ b/impl/src/main/java/org/geomajas/layer/bean/ManyToOneAttributeBean.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/layer/bean/OneToManyAttributeBean.java
+++ b/impl/src/main/java/org/geomajas/layer/bean/OneToManyAttributeBean.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/security/allowall/AllowAllAuthorization.java
+++ b/impl/src/main/java/org/geomajas/security/allowall/AllowAllAuthorization.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/security/allowall/AllowAllSecurityService.java
+++ b/impl/src/main/java/org/geomajas/security/allowall/AllowAllSecurityService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/service/impl/StaticDispatcherUrlService.java
+++ b/impl/src/main/java/org/geomajas/service/impl/StaticDispatcherUrlService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/spring/DependencyCheckPostProcessor.java
+++ b/impl/src/main/java/org/geomajas/spring/DependencyCheckPostProcessor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/spring/GeomajasBeanNameGenerator.java
+++ b/impl/src/main/java/org/geomajas/spring/GeomajasBeanNameGenerator.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/spring/ThreadScope.java
+++ b/impl/src/main/java/org/geomajas/spring/ThreadScope.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/spring/ThreadScopeContext.java
+++ b/impl/src/main/java/org/geomajas/spring/ThreadScopeContext.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/java/org/geomajas/spring/ThreadScopeContextHolder.java
+++ b/impl/src/main/java/org/geomajas/spring/ThreadScopeContextHolder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/main/resources/org/geomajas/spring/emptyApplication.xml
+++ b/impl/src/main/resources/org/geomajas/spring/emptyApplication.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/main/resources/org/geomajas/spring/geomajasContext.xml
+++ b/impl/src/main/resources/org/geomajas/spring/geomajasContext.xml
@@ -1,5 +1,5 @@
 <!-- ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/. 
-	~ ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium. ~
+	~ ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium. ~
 	~ The program is available in open source according to the GNU Affero ~ General 
 	Public License. All contributions in this program are covered ~ by the Geomajas 
 	Contributors License Agreement. For full licensing ~ details, see LICENSE.txt 

--- a/impl/src/main/resources/org/geomajas/spring/geomajasContext.xml
+++ b/impl/src/main/resources/org/geomajas/spring/geomajasContext.xml
@@ -35,7 +35,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas" />
-					<property name="copyright" value="Copyright © 2008-2015 Geosparc nv" />
+					<property name="copyright" value="Copyright © 2008-2016 Geosparc nv" />
 					<property name="licenseName"
 						value="GNU Affero General Public License, Version 3" />
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html" />
@@ -44,7 +44,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 				</bean>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas al" />
-					<property name="copyright" value="Copyright © 2008-2015 Geosparc nv" />
+					<property name="copyright" value="Copyright © 2008-2016 Geosparc nv" />
 					<property name="licenseName" value="Apache License, Version 2.0" />
 					<property name="licenseUrl"
 						value="http://www.apache.org/licenses/LICENSE-2.0.html" />

--- a/impl/src/main/resources/org/geomajas/spring/geomajasWebContext.xml
+++ b/impl/src/main/resources/org/geomajas/spring/geomajasWebContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/main/resources/org/geomajas/spring/testRecorder.xml
+++ b/impl/src/main/resources/org/geomajas/spring/testRecorder.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/configuration/ConfigurationDtoPostProcessorLayerTreeTest.java
+++ b/impl/src/test/java/org/geomajas/internal/configuration/ConfigurationDtoPostProcessorLayerTreeTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/configuration/ConfigurationDtoPostProcessorRasterLayerTest.java
+++ b/impl/src/test/java/org/geomajas/internal/configuration/ConfigurationDtoPostProcessorRasterLayerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/configuration/ConfigurationDtoPostProcessorVectorLayerTest.java
+++ b/impl/src/test/java/org/geomajas/internal/configuration/ConfigurationDtoPostProcessorVectorLayerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/configuration/DummyRasterLayer.java
+++ b/impl/src/test/java/org/geomajas/internal/configuration/DummyRasterLayer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/configuration/ScaleInfoEditorTest.java
+++ b/impl/src/test/java/org/geomajas/internal/configuration/ScaleInfoEditorTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/filter/CqlTest.java
+++ b/impl/src/test/java/org/geomajas/internal/filter/CqlTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/filter/PropertyAccessorTest.java
+++ b/impl/src/test/java/org/geomajas/internal/filter/PropertyAccessorTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/layer/feature/AttributeServiceEditableCapabilityTest.java
+++ b/impl/src/test/java/org/geomajas/internal/layer/feature/AttributeServiceEditableCapabilityTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/layer/feature/AttributeServiceSynthTest.java
+++ b/impl/src/test/java/org/geomajas/internal/layer/feature/AttributeServiceSynthTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/layer/feature/AttributeServiceTest.java
+++ b/impl/src/test/java/org/geomajas/internal/layer/feature/AttributeServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/layer/feature/NameBean.java
+++ b/impl/src/test/java/org/geomajas/internal/layer/feature/NameBean.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/layer/feature/NameDateAttributeBuilder.java
+++ b/impl/src/test/java/org/geomajas/internal/layer/feature/NameDateAttributeBuilder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/layer/tile/TileCodeComparatorTest.java
+++ b/impl/src/test/java/org/geomajas/internal/layer/tile/TileCodeComparatorTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/layer/vector/GetFeaturesEachStepIdAsLabelTest.java
+++ b/impl/src/test/java/org/geomajas/internal/layer/vector/GetFeaturesEachStepIdAsLabelTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/layer/vector/GetFeaturesEachStepSecuredTest.java
+++ b/impl/src/test/java/org/geomajas/internal/layer/vector/GetFeaturesEachStepSecuredTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/layer/vector/GetFeaturesEachStepTest.java
+++ b/impl/src/test/java/org/geomajas/internal/layer/vector/GetFeaturesEachStepTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/layer/vector/OddFeatureAuthorization.java
+++ b/impl/src/test/java/org/geomajas/internal/layer/vector/OddFeatureAuthorization.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/layer/vector/OddFeatureSecurityService.java
+++ b/impl/src/test/java/org/geomajas/internal/layer/vector/OddFeatureSecurityService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/rendering/DefaultSvgDocumentTest.java
+++ b/impl/src/test/java/org/geomajas/internal/rendering/DefaultSvgDocumentTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/rendering/DefaultVmlDocumentTest.java
+++ b/impl/src/test/java/org/geomajas/internal/rendering/DefaultVmlDocumentTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/rendering/StyleFilterTest.java
+++ b/impl/src/test/java/org/geomajas/internal/rendering/StyleFilterTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/security/AllowBaseAuthorization.java
+++ b/impl/src/test/java/org/geomajas/internal/security/AllowBaseAuthorization.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/security/AllowNoneAuthorization.java
+++ b/impl/src/test/java/org/geomajas/internal/security/AllowNoneAuthorization.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/security/AllowNoneWiredAuthorization.java
+++ b/impl/src/test/java/org/geomajas/internal/security/AllowNoneWiredAuthorization.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/security/AuthorizationWiringTest.java
+++ b/impl/src/test/java/org/geomajas/internal/security/AuthorizationWiringTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/security/SecurityContextAreaAuthorizationTest.java
+++ b/impl/src/test/java/org/geomajas/internal/security/SecurityContextAreaAuthorizationTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/security/SecurityContextAttributeAuthorizationTest.java
+++ b/impl/src/test/java/org/geomajas/internal/security/SecurityContextAttributeAuthorizationTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/security/SecurityContextBaseAuthorizationTest.java
+++ b/impl/src/test/java/org/geomajas/internal/security/SecurityContextBaseAuthorizationTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/security/SecurityContextFeatureAuthorizationTest.java
+++ b/impl/src/test/java/org/geomajas/internal/security/SecurityContextFeatureAuthorizationTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/security/SecurityContextFeatureFilterTest.java
+++ b/impl/src/test/java/org/geomajas/internal/security/SecurityContextFeatureFilterTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/security/SecurityContextSaveRestoreTest.java
+++ b/impl/src/test/java/org/geomajas/internal/security/SecurityContextSaveRestoreTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/security/SecurityContextUserInfoTest.java
+++ b/impl/src/test/java/org/geomajas/internal/security/SecurityContextUserInfoTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/security/SecurityManagerLoopTest.java
+++ b/impl/src/test/java/org/geomajas/internal/security/SecurityManagerLoopTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/security/SecurityManagerNoLoopTest.java
+++ b/impl/src/test/java/org/geomajas/internal/security/SecurityManagerNoLoopTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/security/SecurityServiceFirst.java
+++ b/impl/src/test/java/org/geomajas/internal/security/SecurityServiceFirst.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/security/SecurityServiceSecond.java
+++ b/impl/src/test/java/org/geomajas/internal/security/SecurityServiceSecond.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/AttributeConverterTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/AttributeConverterTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/BboxConverterTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/BboxConverterTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/CacheServiceTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/CacheServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/CommandDispatcherSecurityTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/CommandDispatcherSecurityTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/ConfigurationServiceInvalidateTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/ConfigurationServiceInvalidateTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/ConfigurationServiceTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/ConfigurationServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/DummyTestRecorderTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/DummyTestRecorderTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/FeatureConverterTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/FeatureConverterTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/GeoServiceTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/GeoServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/GeoServiceTransformableAreaNonProjectableTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/GeoServiceTransformableAreaNonProjectableTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/GeoServiceTransformableAreaTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/GeoServiceTransformableAreaTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/GeometryConverterTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/GeometryConverterTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/LayerServiceTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/LayerServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/RealTestRecorderTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/RealTestRecorderTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/RecordLayerInvalidateService.java
+++ b/impl/src/test/java/org/geomajas/internal/service/RecordLayerInvalidateService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/ResourceServiceTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/ResourceServiceTest.java
@@ -2,7 +2,7 @@ package org.geomajas.internal.service;
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/StyleServiceTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/StyleServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/TileConverterTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/TileConverterTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/VectorCrsConversionTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/VectorCrsConversionTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/VectorLayerServiceTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/VectorLayerServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/pipeline/ForTestInterceptor.java
+++ b/impl/src/test/java/org/geomajas/internal/service/pipeline/ForTestInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/pipeline/PipelineContextTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/pipeline/PipelineContextTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/pipeline/PipelineServiceInvalidTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/pipeline/PipelineServiceInvalidTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/pipeline/PipelineServiceTest.java
+++ b/impl/src/test/java/org/geomajas/internal/service/pipeline/PipelineServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/pipeline/Step1.java
+++ b/impl/src/test/java/org/geomajas/internal/service/pipeline/Step1.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/pipeline/Step2.java
+++ b/impl/src/test/java/org/geomajas/internal/service/pipeline/Step2.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/pipeline/Step3.java
+++ b/impl/src/test/java/org/geomajas/internal/service/pipeline/Step3.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/pipeline/StepIntercept.java
+++ b/impl/src/test/java/org/geomajas/internal/service/pipeline/StepIntercept.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/internal/service/pipeline/StopStep.java
+++ b/impl/src/test/java/org/geomajas/internal/service/pipeline/StopStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/layer/bean/BeanLayerEditingTest.java
+++ b/impl/src/test/java/org/geomajas/layer/bean/BeanLayerEditingTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/layer/bean/BeanLayerTest.java
+++ b/impl/src/test/java/org/geomajas/layer/bean/BeanLayerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/layer/bean/custombean/CustomBean.java
+++ b/impl/src/test/java/org/geomajas/layer/bean/custombean/CustomBean.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/layer/bean/custombean/CustomBeanLayerTest.java
+++ b/impl/src/test/java/org/geomajas/layer/bean/custombean/CustomBeanLayerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/service/impl/EcqlTest.java
+++ b/impl/src/test/java/org/geomajas/service/impl/EcqlTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/service/impl/StaticDispatcherUrlServiceTest.java
+++ b/impl/src/test/java/org/geomajas/service/impl/StaticDispatcherUrlServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/spring/ConfiguredExample.java
+++ b/impl/src/test/java/org/geomajas/spring/ConfiguredExample.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/spring/Data.java
+++ b/impl/src/test/java/org/geomajas/spring/Data.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/spring/DataBean.java
+++ b/impl/src/test/java/org/geomajas/spring/DataBean.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/spring/DataFactory.java
+++ b/impl/src/test/java/org/geomajas/spring/DataFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/spring/DataFactoryImpl.java
+++ b/impl/src/test/java/org/geomajas/spring/DataFactoryImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/spring/DependencyCheckPostProcessorTest.java
+++ b/impl/src/test/java/org/geomajas/spring/DependencyCheckPostProcessorTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/spring/ExampleImplementation.java
+++ b/impl/src/test/java/org/geomajas/spring/ExampleImplementation.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/spring/ExampleInterface.java
+++ b/impl/src/test/java/org/geomajas/spring/ExampleInterface.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/spring/ScaleInfoHolder.java
+++ b/impl/src/test/java/org/geomajas/spring/ScaleInfoHolder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/spring/SpringIocTest.java
+++ b/impl/src/test/java/org/geomajas/spring/SpringIocTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/spring/ThreadScopeTest.java
+++ b/impl/src/test/java/org/geomajas/spring/ThreadScopeTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/spring/ThreadedService.java
+++ b/impl/src/test/java/org/geomajas/spring/ThreadedService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/string/StringBufferAdd.java
+++ b/impl/src/test/java/org/geomajas/string/StringBufferAdd.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/string/StringBuilderAdd.java
+++ b/impl/src/test/java/org/geomajas/string/StringBuilderAdd.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/java/org/geomajas/string/StringConcatenation.java
+++ b/impl/src/test/java/org/geomajas/string/StringConcatenation.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/logback-test.xml
+++ b/impl/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/configuration/RasterLayerZeroTileHeight.xml
+++ b/impl/src/test/resources/org/geomajas/internal/configuration/RasterLayerZeroTileHeight.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/configuration/RasterLayerZeroTileWidth.xml
+++ b/impl/src/test/resources/org/geomajas/internal/configuration/RasterLayerZeroTileWidth.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/configuration/layerBeansDuplicateAttrManyToOne.xml
+++ b/impl/src/test/resources/org/geomajas/internal/configuration/layerBeansDuplicateAttrManyToOne.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/configuration/layerBeansDuplicateAttrOneToMany.xml
+++ b/impl/src/test/resources/org/geomajas/internal/configuration/layerBeansDuplicateAttrOneToMany.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/configuration/layerBeansDuplicateAttribute.xml
+++ b/impl/src/test/resources/org/geomajas/internal/configuration/layerBeansDuplicateAttribute.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/configuration/layerBeansInvalid.xml
+++ b/impl/src/test/resources/org/geomajas/internal/configuration/layerBeansInvalid.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/configuration/layerDefaultStyle.xml
+++ b/impl/src/test/resources/org/geomajas/internal/configuration/layerDefaultStyle.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/configuration/layerTreeInvalid.xml
+++ b/impl/src/test/resources/org/geomajas/internal/configuration/layerTreeInvalid.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/layer/entity/layerNonEditableBeans.xml
+++ b/impl/src/test/resources/org/geomajas/internal/layer/entity/layerNonEditableBeans.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/layer/feature/syntheticAttributeContext.xml
+++ b/impl/src/test/resources/org/geomajas/internal/layer/feature/syntheticAttributeContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/layer/vector/getFeatureEachStepSynthLabel.xml
+++ b/impl/src/test/resources/org/geomajas/internal/layer/vector/getFeatureEachStepSynthLabel.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/layer/vector/getFeaturesEachStep.xml
+++ b/impl/src/test/resources/org/geomajas/internal/layer/vector/getFeaturesEachStep.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/layer/vector/getFeaturesEachStepIdAsLabel.xml
+++ b/impl/src/test/resources/org/geomajas/internal/layer/vector/getFeaturesEachStepIdAsLabel.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/layer/vector/oddFeatureSecurity.xml
+++ b/impl/src/test/resources/org/geomajas/internal/layer/vector/oddFeatureSecurity.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/rendering/pipeline/pipelineAndDelegate.xml
+++ b/impl/src/test/resources/org/geomajas/internal/rendering/pipeline/pipelineAndDelegate.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/rendering/pipeline/pipelineContext.xml
+++ b/impl/src/test/resources/org/geomajas/internal/rendering/pipeline/pipelineContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/rendering/pipeline/pipelineInvalidExtension.xml
+++ b/impl/src/test/resources/org/geomajas/internal/rendering/pipeline/pipelineInvalidExtension.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/rendering/pipeline/pipelineOverlappingInterceptors.xml
+++ b/impl/src/test/resources/org/geomajas/internal/rendering/pipeline/pipelineOverlappingInterceptors.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/rendering/pipeline/pipelineWrongId.xml
+++ b/impl/src/test/resources/org/geomajas/internal/rendering/pipeline/pipelineWrongId.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/rendering/pipeline/pipelineWrongOrder.xml
+++ b/impl/src/test/resources/org/geomajas/internal/rendering/pipeline/pipelineWrongOrder.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/service/countriesNotAllEditable.xml
+++ b/impl/src/test/resources/org/geomajas/internal/service/countriesNotAllEditable.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/service/featureExpressionServiceContext.xml
+++ b/impl/src/test/resources/org/geomajas/internal/service/featureExpressionServiceContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/service/inMemorySecurityContext.xml
+++ b/impl/src/test/resources/org/geomajas/internal/service/inMemorySecurityContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/service/layerInvalidateContext.xml
+++ b/impl/src/test/resources/org/geomajas/internal/service/layerInvalidateContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/service/legend/rasterLayerContext.xml
+++ b/impl/src/test/resources/org/geomajas/internal/service/legend/rasterLayerContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/internal/service/resourceServiceContext.xml
+++ b/impl/src/test/resources/org/geomajas/internal/service/resourceServiceContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/layer/bean/customBeanContext.xml
+++ b/impl/src/test/resources/org/geomajas/layer/bean/customBeanContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/layer/bean/customLayerBeans.xml
+++ b/impl/src/test/resources/org/geomajas/layer/bean/customLayerBeans.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/layer/bean/layerBeansMercator.xml
+++ b/impl/src/test/resources/org/geomajas/layer/bean/layerBeansMercator.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/layer/bean/layerEditingBeans.xml
+++ b/impl/src/test/resources/org/geomajas/layer/bean/layerEditingBeans.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/dependencyTestDuplicatePluginBad.xml
+++ b/impl/src/test/resources/org/geomajas/spring/dependencyTestDuplicatePluginBad.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/dependencyTestDuplicatePluginGood.xml
+++ b/impl/src/test/resources/org/geomajas/spring/dependencyTestDuplicatePluginGood.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/dependencyTestInIdeBackendDef.xml
+++ b/impl/src/test/resources/org/geomajas/spring/dependencyTestInIdeBackendDef.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/dependencyTestInIdeBackendRef.xml
+++ b/impl/src/test/resources/org/geomajas/spring/dependencyTestInIdeBackendRef.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/dependencyTestInIdePluginDef.xml
+++ b/impl/src/test/resources/org/geomajas/spring/dependencyTestInIdePluginDef.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/dependencyTestInIdePluginRef.xml
+++ b/impl/src/test/resources/org/geomajas/spring/dependencyTestInIdePluginRef.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/dependencyTestNormalBadBackend.xml
+++ b/impl/src/test/resources/org/geomajas/spring/dependencyTestNormalBadBackend.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/dependencyTestNormalBadPlugin.xml
+++ b/impl/src/test/resources/org/geomajas/spring/dependencyTestNormalBadPlugin.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/dependencyTestNormalGood.xml
+++ b/impl/src/test/resources/org/geomajas/spring/dependencyTestNormalGood.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/dependencyTestOptionalBad.xml
+++ b/impl/src/test/resources/org/geomajas/spring/dependencyTestOptionalBad.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/dependencyTestOptionalGood.xml
+++ b/impl/src/test/resources/org/geomajas/spring/dependencyTestOptionalGood.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/dependencyTestOptionalMissing.xml
+++ b/impl/src/test/resources/org/geomajas/spring/dependencyTestOptionalMissing.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/dependencyTestSourceFirst.xml
+++ b/impl/src/test/resources/org/geomajas/spring/dependencyTestSourceFirst.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/dependencyTestSourceLast.xml
+++ b/impl/src/test/resources/org/geomajas/spring/dependencyTestSourceLast.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/editorContext.xml
+++ b/impl/src/test/resources/org/geomajas/spring/editorContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/moreContext.xml
+++ b/impl/src/test/resources/org/geomajas/spring/moreContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/securityLoopContext.xml
+++ b/impl/src/test/resources/org/geomajas/spring/securityLoopContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/securityNoLoopContext.xml
+++ b/impl/src/test/resources/org/geomajas/spring/securityNoLoopContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/securitySerializingContext.xml
+++ b/impl/src/test/resources/org/geomajas/spring/securitySerializingContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/testContext.xml
+++ b/impl/src/test/resources/org/geomajas/spring/testContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/transformableArea.xml
+++ b/impl/src/test/resources/org/geomajas/spring/transformableArea.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/impl/src/test/resources/org/geomajas/spring/transformableAreaNonProjectable.xml
+++ b/impl/src/test/resources/org/geomajas/spring/transformableAreaNonProjectable.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-documentation/pom.xml
+++ b/plugin/cache/cache-documentation/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-documentation/pom.xml
+++ b/plugin/cache/cache-documentation/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.plugin</groupId>

--- a/plugin/cache/cache-documentation/src/docbkx/appendix.xml
+++ b/plugin/cache/cache-documentation/src/docbkx/appendix.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-documentation/src/docbkx/configuration.xml
+++ b/plugin/cache/cache-documentation/src/docbkx/configuration.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-documentation/src/docbkx/howto.xml
+++ b/plugin/cache/cache-documentation/src/docbkx/howto.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-documentation/src/docbkx/introduction.xml
+++ b/plugin/cache/cache-documentation/src/docbkx/introduction.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-documentation/src/docbkx/master.xml
+++ b/plugin/cache/cache-documentation/src/docbkx/master.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-documentation/src/docbkx/master.xml
+++ b/plugin/cache/cache-documentation/src/docbkx/master.xml
@@ -17,7 +17,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2010-2015</year>
+			<year>2010-2016</year>
 
 			<holder>Geosparc nv</holder>
 		</copyright>

--- a/plugin/cache/cache-infinispan/pom.xml
+++ b/plugin/cache/cache-infinispan/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-infinispan/src/main/java/org/geomajas/plugin/caching/infinispan/cache/InfinispanCacheFactory.java
+++ b/plugin/cache/cache-infinispan/src/main/java/org/geomajas/plugin/caching/infinispan/cache/InfinispanCacheFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-infinispan/src/main/java/org/geomajas/plugin/caching/infinispan/cache/InfinispanCacheListener.java
+++ b/plugin/cache/cache-infinispan/src/main/java/org/geomajas/plugin/caching/infinispan/cache/InfinispanCacheListener.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-infinispan/src/main/java/org/geomajas/plugin/caching/infinispan/cache/InfinispanCacheService.java
+++ b/plugin/cache/cache-infinispan/src/main/java/org/geomajas/plugin/caching/infinispan/cache/InfinispanCacheService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-infinispan/src/main/java/org/geomajas/plugin/caching/infinispan/configuration/AbstractInfinispanConfiguration.java
+++ b/plugin/cache/cache-infinispan/src/main/java/org/geomajas/plugin/caching/infinispan/configuration/AbstractInfinispanConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-infinispan/src/main/java/org/geomajas/plugin/caching/infinispan/configuration/InfinispanConfiguration.java
+++ b/plugin/cache/cache-infinispan/src/main/java/org/geomajas/plugin/caching/infinispan/configuration/InfinispanConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-infinispan/src/main/java/org/geomajas/plugin/caching/infinispan/configuration/SimpleInfinispanCacheInfo.java
+++ b/plugin/cache/cache-infinispan/src/main/java/org/geomajas/plugin/caching/infinispan/configuration/SimpleInfinispanCacheInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-infinispan/src/main/resources/META-INF/geomajasContextLayerCacheInfinispan.xml
+++ b/plugin/cache/cache-infinispan/src/main/resources/META-INF/geomajasContextLayerCacheInfinispan.xml
@@ -49,7 +49,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2011 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>

--- a/plugin/cache/cache-infinispan/src/main/resources/META-INF/geomajasContextLayerCacheInfinispan.xml
+++ b/plugin/cache/cache-infinispan/src/main/resources/META-INF/geomajasContextLayerCacheInfinispan.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-infinispan/src/test/java/org/geomajas/plugin/caching/infinispan/DefaultConfigurationTest.java
+++ b/plugin/cache/cache-infinispan/src/test/java/org/geomajas/plugin/caching/infinispan/DefaultConfigurationTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-infinispan/src/test/java/org/geomajas/plugin/caching/infinispan/cache/InfinispanCacheFactoryConfigurationTest.java
+++ b/plugin/cache/cache-infinispan/src/test/java/org/geomajas/plugin/caching/infinispan/cache/InfinispanCacheFactoryConfigurationTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-infinispan/src/test/resources/dummySecurity.xml
+++ b/plugin/cache/cache-infinispan/src/test/resources/dummySecurity.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-infinispan/src/test/resources/infinispanConfiguration.xml
+++ b/plugin/cache/cache-infinispan/src/test/resources/infinispanConfiguration.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-infinispan/src/test/resources/infinispanConfigurationContext.xml
+++ b/plugin/cache/cache-infinispan/src/test/resources/infinispanConfigurationContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-infinispan/src/test/resources/logback-test.xml
+++ b/plugin/cache/cache-infinispan/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache-javadoc/pom.xml
+++ b/plugin/cache/cache-javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/pom.xml
+++ b/plugin/cache/cache/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/cache/NoCacheCacheFactory.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/cache/NoCacheCacheFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/cache/NoCacheCacheService.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/cache/NoCacheCacheService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/configuration/CacheConfiguration.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/configuration/CacheConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/configuration/CacheInfo.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/configuration/CacheInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/index/NoCacheIndexFactory.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/index/NoCacheIndexFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/index/NoCacheIndexService.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/index/NoCacheIndexService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/index/NoInvalidateIndexFactory.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/index/NoInvalidateIndexFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/index/NoInvalidateIndexService.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/index/NoInvalidateIndexService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheCategory.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheCategory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheContext.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheContext.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheContextImpl.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheContextImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheFactory.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheIndexFactory.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheIndexFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheIndexInfo.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheIndexInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheIndexService.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheIndexService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheKeyService.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheKeyService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheKeyServiceImpl.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheKeyServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheLayerInvalidateService.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheLayerInvalidateService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheManagerService.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheManagerService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheManagerServiceImpl.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheManagerServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheService.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheServiceInfo.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CacheServiceInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CachingSupportService.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CachingSupportService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CachingSupportServiceContextAdder.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CachingSupportServiceContextAdder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CachingSupportServiceImpl.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CachingSupportServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CachingSupportServiceSecurityContextAdder.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CachingSupportServiceSecurityContextAdder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CachingSupportServiceSecurityContextAdderImpl.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/CachingSupportServiceSecurityContextAdderImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/IndexedCache.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/IndexedCache.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/LayerCategoryInfo.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/service/LayerCategoryInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/AbstractCachingInterceptor.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/AbstractCachingInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/AbstractSecurityContextCachingInterceptor.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/AbstractSecurityContextCachingInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/BoundsCacheContainer.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/BoundsCacheContainer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/CacheContainer.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/CacheContainer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/CacheStepConstant.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/CacheStepConstant.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/DeleteFeatureInvalidateStep.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/DeleteFeatureInvalidateStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/FeaturesCacheContainer.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/FeaturesCacheContainer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/GetBoundsCachingInterceptor.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/GetBoundsCachingInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/GetFeaturesEachCachingInterceptor.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/GetFeaturesEachCachingInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/GetTileCachingInterceptor.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/GetTileCachingInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/TileCacheContainer.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/TileCacheContainer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/UpdateFeatureInvalidateStep.java
+++ b/plugin/cache/cache/src/main/java/org/geomajas/plugin/caching/step/UpdateFeatureInvalidateStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/resources/META-INF/geomajasContextCache.xml
+++ b/plugin/cache/cache/src/main/resources/META-INF/geomajasContextCache.xml
@@ -50,7 +50,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2011 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>

--- a/plugin/cache/cache/src/main/resources/META-INF/geomajasContextCache.xml
+++ b/plugin/cache/cache/src/main/resources/META-INF/geomajasContextCache.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/main/resources/org/geomajas/plugin/caching/DefaultCachedPipelines.xml
+++ b/plugin/cache/cache/src/main/resources/org/geomajas/plugin/caching/DefaultCachedPipelines.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/configuration/CacheConfigurationDummy.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/configuration/CacheConfigurationDummy.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/configuration/CacheInfoTest.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/configuration/CacheInfoTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/CacheCategoryTest.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/CacheCategoryTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/CacheContextTest.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/CacheContextTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/CacheKeyServiceTest.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/CacheKeyServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/CacheManagerServiceTest.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/CacheManagerServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/DummyCacheFactory.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/DummyCacheFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/DummyCacheIndexFactory.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/DummyCacheIndexFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/DummyCacheIndexService.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/DummyCacheIndexService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/DummyCacheService.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/DummyCacheService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/LayerInvalidateTest.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/service/LayerInvalidateTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/DoNothingStep.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/DoNothingStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetBoundsSecurityTest.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetBoundsSecurityTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetBoundsTest.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetBoundsTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetFeaturesInvalidateDeleteTest.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetFeaturesInvalidateDeleteTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetFeaturesInvalidateUpdateTest.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetFeaturesInvalidateUpdateTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetFeaturesSecurityTest.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetFeaturesSecurityTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetFeaturesTest.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetFeaturesTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetTile2Test.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetTile2Test.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetTileSecurityTest.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetTileSecurityTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetTileTest.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/GetTileTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/RestoreSecurityContextTest.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/RestoreSecurityContextTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/SecurityTestInterceptor.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/SecurityTestInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/StringCacheContainer.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/StringCacheContainer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/StringContainer.java
+++ b/plugin/cache/cache/src/test/java/org/geomajas/plugin/caching/step/StringContainer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/resources/VectorLayerSecurityArea.xml
+++ b/plugin/cache/cache/src/test/resources/VectorLayerSecurityArea.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/resources/cacheServiceContext.xml
+++ b/plugin/cache/cache/src/test/resources/cacheServiceContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/resources/dummySecurity.xml
+++ b/plugin/cache/cache/src/test/resources/dummySecurity.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/resources/logback-test.xml
+++ b/plugin/cache/cache/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/cache/src/test/resources/managerContext.xml
+++ b/plugin/cache/cache/src/test/resources/managerContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/cache/pom.xml
+++ b/plugin/cache/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest-documentation/pom.xml
+++ b/plugin/face-rest/face-rest-documentation/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest-documentation/pom.xml
+++ b/plugin/face-rest/face-rest-documentation/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.documentation</groupId>

--- a/plugin/face-rest/face-rest-documentation/src/docbkx/configuration.xml
+++ b/plugin/face-rest/face-rest-documentation/src/docbkx/configuration.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest-documentation/src/docbkx/introduction.xml
+++ b/plugin/face-rest/face-rest-documentation/src/docbkx/introduction.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest-documentation/src/docbkx/master.xml
+++ b/plugin/face-rest/face-rest-documentation/src/docbkx/master.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest-documentation/src/docbkx/master.xml
+++ b/plugin/face-rest/face-rest-documentation/src/docbkx/master.xml
@@ -17,7 +17,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2010-2015</year>
+			<year>2010-2016</year>
 
 			<holder>Geosparc nv</holder>
 		</copyright>

--- a/plugin/face-rest/face-rest-documentation/src/docbkx/usage.xml
+++ b/plugin/face-rest/face-rest-documentation/src/docbkx/usage.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest-example/pom.xml
+++ b/plugin/face-rest/face-rest-example/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest-example/src/main/resources/org/geomajas/rest/shapeinmem/applicationContext.xml
+++ b/plugin/face-rest/face-rest-example/src/main/resources/org/geomajas/rest/shapeinmem/applicationContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest-example/src/main/resources/org/geomajas/rest/shapeinmem/layerCountries110m.xml
+++ b/plugin/face-rest/face-rest-example/src/main/resources/org/geomajas/rest/shapeinmem/layerCountries110m.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest-example/src/main/webapp/OpenLayers.js
+++ b/plugin/face-rest/face-rest-example/src/main/webapp/OpenLayers.js
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest-example/src/main/webapp/WEB-INF/web.xml
+++ b/plugin/face-rest/face-rest-example/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest-example/src/main/webapp/index.html
+++ b/plugin/face-rest/face-rest-example/src/main/webapp/index.html
@@ -3,7 +3,7 @@
 		<!--
 		  ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 		  ~
-		  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+		  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 		  ~
 		  ~ The program is available in open source according to the GNU Affero
 		  ~ General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest-example/src/main/webapp/theme/default/framedCloud.css
+++ b/plugin/face-rest/face-rest-example/src/main/webapp/theme/default/framedCloud.css
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest-example/src/main/webapp/theme/default/google.css
+++ b/plugin/face-rest/face-rest-example/src/main/webapp/theme/default/google.css
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest-example/src/main/webapp/theme/default/ie6-style.css
+++ b/plugin/face-rest/face-rest-example/src/main/webapp/theme/default/ie6-style.css
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest-example/src/main/webapp/theme/default/style.css
+++ b/plugin/face-rest/face-rest-example/src/main/webapp/theme/default/style.css
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest-javadoc/pom.xml
+++ b/plugin/face-rest/face-rest-javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/pom.xml
+++ b/plugin/face-rest/face-rest/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/GeoJsonParser.java
+++ b/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/GeoJsonParser.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/GeoToolsConverterService.java
+++ b/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/GeoToolsConverterService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/GeoToolsConverterServiceImpl.java
+++ b/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/GeoToolsConverterServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/KmlParser.java
+++ b/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/KmlParser.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/RestException.java
+++ b/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/RestException.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/ShpParser.java
+++ b/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/ShpParser.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/TxtParser.java
+++ b/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/TxtParser.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/FeatureOrder.java
+++ b/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/FeatureOrder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/GeoJsonView.java
+++ b/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/GeoJsonView.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/KmlView.java
+++ b/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/KmlView.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/RestController.java
+++ b/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/RestController.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/RestParameterConversionService.java
+++ b/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/RestParameterConversionService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/ShpView.java
+++ b/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/ShpView.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/StringToEnvelopeConverter.java
+++ b/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/StringToEnvelopeConverter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/StringToStringArrayConverter.java
+++ b/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/StringToStringArrayConverter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/TxtView.java
+++ b/plugin/face-rest/face-rest/src/main/java/org/geomajas/rest/server/mvc/TxtView.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/resources/META-INF/geomajasContextFaceRest.xml
+++ b/plugin/face-rest/face-rest/src/main/resources/META-INF/geomajasContextFaceRest.xml
@@ -41,7 +41,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2011 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>

--- a/plugin/face-rest/face-rest/src/main/resources/META-INF/geomajasContextFaceRest.xml
+++ b/plugin/face-rest/face-rest/src/main/resources/META-INF/geomajasContextFaceRest.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/resources/META-INF/geomajasWebContextFaceRest.xml
+++ b/plugin/face-rest/face-rest/src/main/resources/META-INF/geomajasWebContextFaceRest.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/main/resources/org/geomajas/rest/server/RestException.properties
+++ b/plugin/face-rest/face-rest/src/main/resources/org/geomajas/rest/server/RestException.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/test/java/org/geomajas/rest/server/GeotoolsconverterServiceTest.java
+++ b/plugin/face-rest/face-rest/src/test/java/org/geomajas/rest/server/GeotoolsconverterServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/test/java/org/geomajas/rest/server/mvc/RestControllerTest.java
+++ b/plugin/face-rest/face-rest/src/test/java/org/geomajas/rest/server/mvc/RestControllerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/test/java/org/geomajas/rest/server/mvc/StringToEnvelopeConverterTest.java
+++ b/plugin/face-rest/face-rest/src/test/java/org/geomajas/rest/server/mvc/StringToEnvelopeConverterTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/test/java/org/geomajas/rest/server/mvc/StringToStringArrayConverterTest.java
+++ b/plugin/face-rest/face-rest/src/test/java/org/geomajas/rest/server/mvc/StringToStringArrayConverterTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/test/resources/logback-test.xml
+++ b/plugin/face-rest/face-rest/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/face-rest/face-rest/src/test/resources/org/geomajas/rest/geomajasContext.xml
+++ b/plugin/face-rest/face-rest/src/test/resources/org/geomajas/rest/geomajasContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/face-rest/pom.xml
+++ b/plugin/face-rest/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder-documentation/pom.xml
+++ b/plugin/geocoder/geocoder-documentation/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder-documentation/pom.xml
+++ b/plugin/geocoder/geocoder-documentation/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.plugin</groupId>

--- a/plugin/geocoder/geocoder-documentation/src/docbkx/howto.xml
+++ b/plugin/geocoder/geocoder-documentation/src/docbkx/howto.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2013 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder-documentation/src/docbkx/introduction.xml
+++ b/plugin/geocoder/geocoder-documentation/src/docbkx/introduction.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder-documentation/src/docbkx/master.xml
+++ b/plugin/geocoder/geocoder-documentation/src/docbkx/master.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder-documentation/src/docbkx/master.xml
+++ b/plugin/geocoder/geocoder-documentation/src/docbkx/master.xml
@@ -17,7 +17,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2010-2015</year>
+			<year>2010-2016</year>
 
 			<holder>Geosparc nv</holder>
 		</copyright>

--- a/plugin/geocoder/geocoder-documentation/src/docbkx/use.xml
+++ b/plugin/geocoder/geocoder-documentation/src/docbkx/use.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2013 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder-javadoc/pom.xml
+++ b/plugin/geocoder/geocoder-javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/pom.xml
+++ b/plugin/geocoder/geocoder/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/api/CombineResultService.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/api/CombineResultService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/api/GeocoderInfo.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/api/GeocoderInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/api/GeocoderService.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/api/GeocoderService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/api/GetLocationResult.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/api/GetLocationResult.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/api/SplitGeocoderStringService.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/api/SplitGeocoderStringService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/api/StaticRegexGeocoderInfo.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/api/StaticRegexGeocoderInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/api/StaticRegexGeocoderLocationInfo.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/api/StaticRegexGeocoderLocationInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/command/dto/GetLocationForStringAlternative.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/command/dto/GetLocationForStringAlternative.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/command/dto/GetLocationForStringRequest.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/command/dto/GetLocationForStringRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/command/dto/GetLocationForStringResponse.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/command/dto/GetLocationForStringResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/command/geocoder/GetLocationForStringCommand.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/command/geocoder/GetLocationForStringCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/service/CombineIntersectionService.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/service/CombineIntersectionService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/service/CombineUnionService.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/service/CombineUnionService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/service/GeocoderUtilService.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/service/GeocoderUtilService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/service/GeonamesGeocoderService.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/service/GeonamesGeocoderService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/service/SplitCommaReverseService.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/service/SplitCommaReverseService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/service/StaticRegexGeocoderService.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/service/StaticRegexGeocoderService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/service/TypeCoordinateService.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/service/TypeCoordinateService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/service/YahooPlaceFinderGeocoderService.java
+++ b/plugin/geocoder/geocoder/src/main/java/org/geomajas/plugin/geocoder/service/YahooPlaceFinderGeocoderService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/main/resources/META-INF/geomajasContextGeocoder.xml
+++ b/plugin/geocoder/geocoder/src/main/resources/META-INF/geomajasContextGeocoder.xml
@@ -41,7 +41,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2011 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>

--- a/plugin/geocoder/geocoder/src/main/resources/META-INF/geomajasContextGeocoder.xml
+++ b/plugin/geocoder/geocoder/src/main/resources/META-INF/geomajasContextGeocoder.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/command/geocoder/GetLocationForStringCommandAltTest.java
+++ b/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/command/geocoder/GetLocationForStringCommandAltTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/command/geocoder/GetLocationForStringCommandCombineTest.java
+++ b/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/command/geocoder/GetLocationForStringCommandCombineTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/command/geocoder/GetLocationForStringCommandMaxTest.java
+++ b/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/command/geocoder/GetLocationForStringCommandMaxTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/command/geocoder/GetLocationForStringCommandTest.java
+++ b/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/command/geocoder/GetLocationForStringCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/command/geocoder/GetLocationForStringNameSelectTest.java
+++ b/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/command/geocoder/GetLocationForStringNameSelectTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/CombineIntersectionServiceTest.java
+++ b/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/CombineIntersectionServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/CombineUnionServiceTest.java
+++ b/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/CombineUnionServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/GeocoderUtilServiceTest.java
+++ b/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/GeocoderUtilServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/GeonamesGeocoderServiceTest.java
+++ b/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/GeonamesGeocoderServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/SplitCommaReverseServiceTest.java
+++ b/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/SplitCommaReverseServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/StaticRegexGeocoderServiceTest.java
+++ b/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/StaticRegexGeocoderServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/TypeCoordinateServiceTest.java
+++ b/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/TypeCoordinateServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/UserDataTestInfo.java
+++ b/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/UserDataTestInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/YahooPlaceFinderGeocoderService2Test.java
+++ b/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/YahooPlaceFinderGeocoderService2Test.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/YahooPlaceFinderGeocoderServiceTest.java
+++ b/plugin/geocoder/geocoder/src/test/java/org/geomajas/plugin/geocoder/service/YahooPlaceFinderGeocoderServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/resources/completeAltContext.xml
+++ b/plugin/geocoder/geocoder/src/test/resources/completeAltContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/resources/completeCombineContext.xml
+++ b/plugin/geocoder/geocoder/src/test/resources/completeCombineContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/resources/completeContext.xml
+++ b/plugin/geocoder/geocoder/src/test/resources/completeContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/resources/logback-test.xml
+++ b/plugin/geocoder/geocoder/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/resources/maxContext.xml
+++ b/plugin/geocoder/geocoder/src/test/resources/maxContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/resources/nameSelectContext.xml
+++ b/plugin/geocoder/geocoder/src/test/resources/nameSelectContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/resources/tcsContext.xml
+++ b/plugin/geocoder/geocoder/src/test/resources/tcsContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/resources/ypf2Context.xml
+++ b/plugin/geocoder/geocoder/src/test/resources/ypf2Context.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/geocoder/src/test/resources/ypfContext.xml
+++ b/plugin/geocoder/geocoder/src/test/resources/ypfContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/geocoder/pom.xml
+++ b/plugin/geocoder/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common-documentation/pom.xml
+++ b/plugin/layer-common/layer-common-documentation/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.plugin</groupId>

--- a/plugin/layer-common/layer-common-documentation/pom.xml
+++ b/plugin/layer-common/layer-common-documentation/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common-documentation/src/docbkx/configuration.xml
+++ b/plugin/layer-common/layer-common-documentation/src/docbkx/configuration.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common-documentation/src/docbkx/howto.xml
+++ b/plugin/layer-common/layer-common-documentation/src/docbkx/howto.xml
@@ -4,7 +4,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common-documentation/src/docbkx/introduction.xml
+++ b/plugin/layer-common/layer-common-documentation/src/docbkx/introduction.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common-documentation/src/docbkx/master.xml
+++ b/plugin/layer-common/layer-common-documentation/src/docbkx/master.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common-documentation/src/docbkx/master.xml
+++ b/plugin/layer-common/layer-common-documentation/src/docbkx/master.xml
@@ -17,7 +17,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2013-2015</year>
+			<year>2013-2016</year>
 			<holder>Geosparc nv</holder>
 		</copyright>
 

--- a/plugin/layer-common/layer-common-javadoc/pom.xml
+++ b/plugin/layer-common/layer-common-javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common/pom.xml
+++ b/plugin/layer-common/layer-common/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/CachingLayerHttpService.java
+++ b/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/CachingLayerHttpService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/LayerAuthentication.java
+++ b/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/LayerAuthentication.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/LayerAuthenticationMethod.java
+++ b/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/LayerAuthenticationMethod.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/LayerHttpService.java
+++ b/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/LayerHttpService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/LayerHttpServiceImpl.java
+++ b/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/LayerHttpServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/LayerHttpServiceInterceptors.java
+++ b/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/LayerHttpServiceInterceptors.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/ProxyAuthentication.java
+++ b/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/ProxyAuthentication.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/ProxyAuthenticationMethod.java
+++ b/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/ProxyAuthenticationMethod.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/ProxyLayerSupport.java
+++ b/plugin/layer-common/layer-common/src/main/java/org/geomajas/layer/common/proxy/ProxyLayerSupport.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common/src/main/resources/META-INF/geomajasContextLayerCommon.xml
+++ b/plugin/layer-common/layer-common/src/main/resources/META-INF/geomajasContextLayerCommon.xml
@@ -39,7 +39,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2015 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>

--- a/plugin/layer-common/layer-common/src/main/resources/META-INF/geomajasContextLayerCommon.xml
+++ b/plugin/layer-common/layer-common/src/main/resources/META-INF/geomajasContextLayerCommon.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common/src/test/java/org/geomajas/layer/common/proxy/LayerHttpServiceTest.java
+++ b/plugin/layer-common/layer-common/src/test/java/org/geomajas/layer/common/proxy/LayerHttpServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common/src/test/java/org/geomajas/layer/common/proxy/MockProxyLayer.java
+++ b/plugin/layer-common/layer-common/src/test/java/org/geomajas/layer/common/proxy/MockProxyLayer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common/src/test/resources/logback-test.xml
+++ b/plugin/layer-common/layer-common/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-common/layer-common/src/test/resources/org/geomajas/layer/common/layerHttpTest.xml
+++ b/plugin/layer-common/layer-common/src/test/resources/org/geomajas/layer/common/layerHttpTest.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-common/pom.xml
+++ b/plugin/layer-common/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools-documentation/pom.xml
+++ b/plugin/layer-geotools/geotools-documentation/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.plugin</groupId>

--- a/plugin/layer-geotools/geotools-documentation/pom.xml
+++ b/plugin/layer-geotools/geotools-documentation/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools-documentation/src/docbkx/configuration.xml
+++ b/plugin/layer-geotools/geotools-documentation/src/docbkx/configuration.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools-documentation/src/docbkx/howto.xml
+++ b/plugin/layer-geotools/geotools-documentation/src/docbkx/howto.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools-documentation/src/docbkx/introduction.xml
+++ b/plugin/layer-geotools/geotools-documentation/src/docbkx/introduction.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools-documentation/src/docbkx/master.xml
+++ b/plugin/layer-geotools/geotools-documentation/src/docbkx/master.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools-documentation/src/docbkx/master.xml
+++ b/plugin/layer-geotools/geotools-documentation/src/docbkx/master.xml
@@ -17,7 +17,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2010-2015</year>
+			<year>2010-2016</year>
 
 			<holder>Geosparc nv</holder>
 		</copyright>

--- a/plugin/layer-geotools/geotools-javadoc/pom.xml
+++ b/plugin/layer-geotools/geotools-javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/pom.xml
+++ b/plugin/layer-geotools/geotools/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/geotools/DataStoreFactory.java
+++ b/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/geotools/DataStoreFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/geotools/GeoDbDataSource.java
+++ b/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/geotools/GeoDbDataSource.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/geotools/GeoToolsFeatureModel.java
+++ b/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/geotools/GeoToolsFeatureModel.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/geotools/GeoToolsLayer.java
+++ b/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/geotools/GeoToolsLayer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/geotools/GeoToolsTransactionManager.java
+++ b/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/geotools/GeoToolsTransactionManager.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/geotools/GeoToolsTransactionSynchronization.java
+++ b/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/geotools/GeoToolsTransactionSynchronization.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/shapeinmem/FeatureSourceRetriever.java
+++ b/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/shapeinmem/FeatureSourceRetriever.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/shapeinmem/ShapeInMemFeatureModel.java
+++ b/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/shapeinmem/ShapeInMemFeatureModel.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/shapeinmem/ShapeInMemLayer.java
+++ b/plugin/layer-geotools/geotools/src/main/java/org/geomajas/layer/shapeinmem/ShapeInMemLayer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/main/resources/META-INF/geomajasContextLayerGeotools.xml
+++ b/plugin/layer-geotools/geotools/src/main/resources/META-INF/geomajasContextLayerGeotools.xml
@@ -31,7 +31,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2011 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>

--- a/plugin/layer-geotools/geotools/src/main/resources/META-INF/geomajasContextLayerGeotools.xml
+++ b/plugin/layer-geotools/geotools/src/main/resources/META-INF/geomajasContextLayerGeotools.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/geotools/AbstractGeoToolsTest.java
+++ b/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/geotools/AbstractGeoToolsTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/geotools/DataStoreStartWfsTest.java
+++ b/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/geotools/DataStoreStartWfsTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/geotools/GeoToolsFeatureModelTest.java
+++ b/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/geotools/GeoToolsFeatureModelTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/geotools/GeoToolsFilterTest.java
+++ b/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/geotools/GeoToolsFilterTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/geotools/GeoToolsLayerTest.java
+++ b/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/geotools/GeoToolsLayerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/geotools/WfsLayerTest.java
+++ b/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/geotools/WfsLayerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/shapeinmem/AbstractFilterTest.java
+++ b/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/shapeinmem/AbstractFilterTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/shapeinmem/ShapeInMemFeatureModelTest.java
+++ b/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/shapeinmem/ShapeInMemFeatureModelTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/shapeinmem/ShapeInMemFilterTest.java
+++ b/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/shapeinmem/ShapeInMemFilterTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/shapeinmem/ShapeInMemLayerTest.java
+++ b/plugin/layer-geotools/geotools/src/test/java/org/geomajas/layer/shapeinmem/ShapeInMemLayerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/resources/logback-test.xml
+++ b/plugin/layer-geotools/geotools/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/geotools/dataStoreCannotStart.xml
+++ b/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/geotools/dataStoreCannotStart.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/geotools/dataStoreFactory.xml
+++ b/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/geotools/dataStoreFactory.xml
@@ -1,5 +1,5 @@
 <!-- ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/. 
-	~ ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium. ~
+	~ ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium. ~
 	~ The program is available in open source according to the GNU Affero ~ General 
 	Public License. All contributions in this program are covered ~ by the Geomajas 
 	Contributors License Agreement. For full licensing ~ details, see LICENSE.txt 

--- a/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/geotools/layerPoint.xml
+++ b/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/geotools/layerPoint.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/geotools/layerPopulatedPlaces110m.xml
+++ b/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/geotools/layerPopulatedPlaces110m.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/geotools/test.xml
+++ b/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/geotools/test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/geotools/wfsLayer.xml
+++ b/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/geotools/wfsLayer.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/layerAirportsForExtract.xml
+++ b/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/layerAirportsForExtract.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/shapeinmem/test.xml
+++ b/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/shapeinmem/test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/transaction.xml
+++ b/plugin/layer-geotools/geotools/src/test/resources/org/geomajas/layer/transaction.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-geotools/pom.xml
+++ b/plugin/layer-geotools/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-googlemaps/googlemaps-documentation/pom.xml
+++ b/plugin/layer-googlemaps/googlemaps-documentation/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.plugin</groupId>

--- a/plugin/layer-googlemaps/googlemaps-documentation/pom.xml
+++ b/plugin/layer-googlemaps/googlemaps-documentation/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-googlemaps/googlemaps-documentation/src/docbkx/configuration.xml
+++ b/plugin/layer-googlemaps/googlemaps-documentation/src/docbkx/configuration.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-googlemaps/googlemaps-documentation/src/docbkx/introduction.xml
+++ b/plugin/layer-googlemaps/googlemaps-documentation/src/docbkx/introduction.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-googlemaps/googlemaps-documentation/src/docbkx/master.xml
+++ b/plugin/layer-googlemaps/googlemaps-documentation/src/docbkx/master.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-googlemaps/googlemaps-documentation/src/docbkx/master.xml
+++ b/plugin/layer-googlemaps/googlemaps-documentation/src/docbkx/master.xml
@@ -17,7 +17,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2010-2015</year>
+			<year>2010-2016</year>
 
 			<holder>Geosparc nv</holder>
 		</copyright>

--- a/plugin/layer-googlemaps/googlemaps-javadoc/pom.xml
+++ b/plugin/layer-googlemaps/googlemaps-javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-googlemaps/googlemaps/pom.xml
+++ b/plugin/layer-googlemaps/googlemaps/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-googlemaps/googlemaps/src/main/java/org/geomajas/layer/google/GoogleLayer.java
+++ b/plugin/layer-googlemaps/googlemaps/src/main/java/org/geomajas/layer/google/GoogleLayer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-googlemaps/googlemaps/src/main/resources/META-INF/geomajasContextLayerGooglemaps.xml
+++ b/plugin/layer-googlemaps/googlemaps/src/main/resources/META-INF/geomajasContextLayerGooglemaps.xml
@@ -35,7 +35,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2011 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>

--- a/plugin/layer-googlemaps/googlemaps/src/main/resources/META-INF/geomajasContextLayerGooglemaps.xml
+++ b/plugin/layer-googlemaps/googlemaps/src/main/resources/META-INF/geomajasContextLayerGooglemaps.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-googlemaps/googlemaps/src/test/java/org/geomajas/layer/google/GoogleLayerTest.java
+++ b/plugin/layer-googlemaps/googlemaps/src/test/java/org/geomajas/layer/google/GoogleLayerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-googlemaps/googlemaps/src/test/resources/googleContext.xml
+++ b/plugin/layer-googlemaps/googlemaps/src/test/resources/googleContext.xml
@@ -1,5 +1,5 @@
 <!-- ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/. 
-	~ ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium. ~
+	~ ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium. ~
 	~ The program is available in open source according to the GNU Affero ~ General 
 	Public License. All contributions in this program are covered ~ by the Geomajas 
 	Contributors License Agreement. For full licensing ~ details, see LICENSE.txt 

--- a/plugin/layer-googlemaps/googlemaps/src/test/resources/logback-test.xml
+++ b/plugin/layer-googlemaps/googlemaps/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-googlemaps/pom.xml
+++ b/plugin/layer-googlemaps/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate-documentation/pom.xml
+++ b/plugin/layer-hibernate/hibernate-documentation/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.plugin</groupId>

--- a/plugin/layer-hibernate/hibernate-documentation/pom.xml
+++ b/plugin/layer-hibernate/hibernate-documentation/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate-documentation/src/docbkx/configuration.xml
+++ b/plugin/layer-hibernate/hibernate-documentation/src/docbkx/configuration.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate-documentation/src/docbkx/howto.xml
+++ b/plugin/layer-hibernate/hibernate-documentation/src/docbkx/howto.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate-documentation/src/docbkx/introduction.xml
+++ b/plugin/layer-hibernate/hibernate-documentation/src/docbkx/introduction.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate-documentation/src/docbkx/master.xml
+++ b/plugin/layer-hibernate/hibernate-documentation/src/docbkx/master.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate-documentation/src/docbkx/master.xml
+++ b/plugin/layer-hibernate/hibernate-documentation/src/docbkx/master.xml
@@ -17,7 +17,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2010-2015</year>
+			<year>2010-2016</year>
 
 			<holder>Geosparc nv</holder>
 		</copyright>

--- a/plugin/layer-hibernate/hibernate-javadoc/pom.xml
+++ b/plugin/layer-hibernate/hibernate-javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/pom.xml
+++ b/plugin/layer-hibernate/hibernate/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/CriteriaVisitor.java
+++ b/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/CriteriaVisitor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/GenericDao.java
+++ b/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/GenericDao.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/HSQLSpatialDialect.java
+++ b/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/HSQLSpatialDialect.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/HSQLSpatialDialectProvider.java
+++ b/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/HSQLSpatialDialectProvider.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/HibernateEntityMapper.java
+++ b/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/HibernateEntityMapper.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/HibernateFeatureModel.java
+++ b/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/HibernateFeatureModel.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/HibernateLayer.java
+++ b/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/HibernateLayer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/HibernateLayerException.java
+++ b/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/HibernateLayerException.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/HibernateLayerUtil.java
+++ b/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/HibernateLayerUtil.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/HsqlGeometryUserType.java
+++ b/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/HsqlGeometryUserType.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/filter/ExtendedFilterFactory.java
+++ b/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/filter/ExtendedFilterFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/filter/ExtendedLikeFilterImpl.java
+++ b/plugin/layer-hibernate/hibernate/src/main/java/org/geomajas/layer/hibernate/filter/ExtendedLikeFilterImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/main/resources/META-INF/geomajasContextLayerHibernate.xml
+++ b/plugin/layer-hibernate/hibernate/src/main/resources/META-INF/geomajasContextLayerHibernate.xml
@@ -31,7 +31,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2011 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>

--- a/plugin/layer-hibernate/hibernate/src/main/resources/META-INF/geomajasContextLayerHibernate.xml
+++ b/plugin/layer-hibernate/hibernate/src/main/resources/META-INF/geomajasContextLayerHibernate.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/AbstractHibernateAssociationTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/AbstractHibernateAssociationTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/AbstractHibernateInheritanceTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/AbstractHibernateInheritanceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/AbstractHibernateLayerModelTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/AbstractHibernateLayerModelTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/AbstractHibernateNestedTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/AbstractHibernateNestedTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/AbstractHibernateSimpleTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/AbstractHibernateSimpleTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/HibernateFeatureModelTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/HibernateFeatureModelTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/HibernateFilterAttributeTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/HibernateFilterAttributeTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/HibernateFilterManyToOneTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/HibernateFilterManyToOneTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/HibernateFilterOneToManyTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/HibernateFilterOneToManyTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/HibernateLayerSimplifiedConfigTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/HibernateLayerSimplifiedConfigTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/HibernateLayerTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/HibernateLayerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/PersistTransactionCommandTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/PersistTransactionCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/association/AssociationFeatureModelTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/association/AssociationFeatureModelTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/association/AssociationLayerTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/association/AssociationLayerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/association/CriteriaVisitorTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/association/CriteriaVisitorTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/association/FilterManyToOneTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/association/FilterManyToOneTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/association/FilterOneToManyTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/association/FilterOneToManyTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/association/pojo/AssociationFeature.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/association/pojo/AssociationFeature.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/association/pojo/ManyToOneProperty.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/association/pojo/ManyToOneProperty.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/association/pojo/OneToManyProperty.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/association/pojo/OneToManyProperty.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/inheritance/InheritanceFeatureModelTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/inheritance/InheritanceFeatureModelTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/inheritance/pojo/AbstractAttribute.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/inheritance/pojo/AbstractAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/inheritance/pojo/AbstractHibernateTestFeature.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/inheritance/pojo/AbstractHibernateTestFeature.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/inheritance/pojo/ExtendedAttribute.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/inheritance/pojo/ExtendedAttribute.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/inheritance/pojo/ExtendedHibernateTestFeature.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/inheritance/pojo/ExtendedHibernateTestFeature.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/pojo/HibernateTestFeature.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/pojo/HibernateTestFeature.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/pojo/HibernateTestManyToOne.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/pojo/HibernateTestManyToOne.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/pojo/HibernateTestOneToMany.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/pojo/HibernateTestOneToMany.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/simple/CriteriaVisitorTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/simple/CriteriaVisitorTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/simple/SimpleFeatureModelTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/simple/SimpleFeatureModelTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/simple/SimpleFilterTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/simple/SimpleFilterTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/simple/SimpleLayerTest.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/simple/SimpleLayerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/simple/pojo/SimpleFeature.java
+++ b/plugin/layer-hibernate/hibernate/src/test/java/org/geomajas/layer/hibernate/simple/pojo/SimpleFeature.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/resources/associationContext.xml
+++ b/plugin/layer-hibernate/hibernate/src/test/resources/associationContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/resources/featureInfo.xml
+++ b/plugin/layer-hibernate/hibernate/src/test/resources/featureInfo.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/resources/hibernate-spatial.cfg.xml
+++ b/plugin/layer-hibernate/hibernate/src/test/resources/hibernate-spatial.cfg.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/resources/hibernate.cfg.xml
+++ b/plugin/layer-hibernate/hibernate/src/test/resources/hibernate.cfg.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/resources/inheritanceContext.xml
+++ b/plugin/layer-hibernate/hibernate/src/test/resources/inheritanceContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/resources/logback-test.xml
+++ b/plugin/layer-hibernate/hibernate/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/resources/nestedContext.xml
+++ b/plugin/layer-hibernate/hibernate/src/test/resources/nestedContext.xml
@@ -1,5 +1,5 @@
 <!-- ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/. 
-	~ ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium. ~
+	~ ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium. ~
 	~ The program is available in open source according to the GNU Affero ~ General 
 	Public License. All contributions in this program are covered ~ by the Geomajas 
 	Contributors License Agreement. For full licensing ~ details, see LICENSE.txt 

--- a/plugin/layer-hibernate/hibernate/src/test/resources/simpleContext.xml
+++ b/plugin/layer-hibernate/hibernate/src/test/resources/simpleContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/resources/spring-hibernate.xml
+++ b/plugin/layer-hibernate/hibernate/src/test/resources/spring-hibernate.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/resources/testContext.xml
+++ b/plugin/layer-hibernate/hibernate/src/test/resources/testContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/hibernate/src/test/resources/testContextSimplifiedConfig.xml
+++ b/plugin/layer-hibernate/hibernate/src/test/resources/testContextSimplifiedConfig.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-hibernate/pom.xml
+++ b/plugin/layer-hibernate/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/openstreetmap-documentation/pom.xml
+++ b/plugin/layer-openstreetmap/openstreetmap-documentation/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.plugin</groupId>

--- a/plugin/layer-openstreetmap/openstreetmap-documentation/pom.xml
+++ b/plugin/layer-openstreetmap/openstreetmap-documentation/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/openstreetmap-documentation/src/docbkx/configuration.xml
+++ b/plugin/layer-openstreetmap/openstreetmap-documentation/src/docbkx/configuration.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/openstreetmap-documentation/src/docbkx/introduction.xml
+++ b/plugin/layer-openstreetmap/openstreetmap-documentation/src/docbkx/introduction.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/openstreetmap-documentation/src/docbkx/master.xml
+++ b/plugin/layer-openstreetmap/openstreetmap-documentation/src/docbkx/master.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/openstreetmap-documentation/src/docbkx/master.xml
+++ b/plugin/layer-openstreetmap/openstreetmap-documentation/src/docbkx/master.xml
@@ -17,7 +17,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2010-2015</year>
+			<year>2010-2016</year>
 
 			<holder>Geosparc nv</holder>
 		</copyright>

--- a/plugin/layer-openstreetmap/openstreetmap-javadoc/pom.xml
+++ b/plugin/layer-openstreetmap/openstreetmap-javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/openstreetmap/pom.xml
+++ b/plugin/layer-openstreetmap/openstreetmap/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/openstreetmap/src/main/java/org/geomajas/layer/osm/OsmLayer.java
+++ b/plugin/layer-openstreetmap/openstreetmap/src/main/java/org/geomajas/layer/osm/OsmLayer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/openstreetmap/src/main/java/org/geomajas/layer/osm/RoundRobinUrlSelectionStrategy.java
+++ b/plugin/layer-openstreetmap/openstreetmap/src/main/java/org/geomajas/layer/osm/RoundRobinUrlSelectionStrategy.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/openstreetmap/src/main/java/org/geomajas/layer/osm/TiledRasterLayerService.java
+++ b/plugin/layer-openstreetmap/openstreetmap/src/main/java/org/geomajas/layer/osm/TiledRasterLayerService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/openstreetmap/src/main/java/org/geomajas/layer/osm/TiledRasterLayerServiceState.java
+++ b/plugin/layer-openstreetmap/openstreetmap/src/main/java/org/geomajas/layer/osm/TiledRasterLayerServiceState.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/openstreetmap/src/main/java/org/geomajas/layer/osm/UrlSelectionStrategy.java
+++ b/plugin/layer-openstreetmap/openstreetmap/src/main/java/org/geomajas/layer/osm/UrlSelectionStrategy.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/openstreetmap/src/main/resources/META-INF/geomajasContextLayerOpenstreetmap.xml
+++ b/plugin/layer-openstreetmap/openstreetmap/src/main/resources/META-INF/geomajasContextLayerOpenstreetmap.xml
@@ -31,7 +31,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2011 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>

--- a/plugin/layer-openstreetmap/openstreetmap/src/main/resources/META-INF/geomajasContextLayerOpenstreetmap.xml
+++ b/plugin/layer-openstreetmap/openstreetmap/src/main/resources/META-INF/geomajasContextLayerOpenstreetmap.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/openstreetmap/src/test/java/org/geomajas/layer/osm/LastUrlSelectionStrategy.java
+++ b/plugin/layer-openstreetmap/openstreetmap/src/test/java/org/geomajas/layer/osm/LastUrlSelectionStrategy.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/openstreetmap/src/test/java/org/geomajas/layer/osm/OsmLayerTest.java
+++ b/plugin/layer-openstreetmap/openstreetmap/src/test/java/org/geomajas/layer/osm/OsmLayerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/openstreetmap/src/test/java/org/geomajas/layer/osm/RoundRobinUrlSelectionStrategyTest.java
+++ b/plugin/layer-openstreetmap/openstreetmap/src/test/java/org/geomajas/layer/osm/RoundRobinUrlSelectionStrategyTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/openstreetmap/src/test/resources/logback-test.xml
+++ b/plugin/layer-openstreetmap/openstreetmap/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/openstreetmap/src/test/resources/osmContext.xml
+++ b/plugin/layer-openstreetmap/openstreetmap/src/test/resources/osmContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-openstreetmap/pom.xml
+++ b/plugin/layer-openstreetmap/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/pom.xml
+++ b/plugin/layer-tms/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms-documentation/pom.xml
+++ b/plugin/layer-tms/tms-documentation/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.plugin</groupId>

--- a/plugin/layer-tms/tms-documentation/pom.xml
+++ b/plugin/layer-tms/tms-documentation/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms-documentation/src/docbkx/configuration.xml
+++ b/plugin/layer-tms/tms-documentation/src/docbkx/configuration.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms-documentation/src/docbkx/howto.xml
+++ b/plugin/layer-tms/tms-documentation/src/docbkx/howto.xml
@@ -4,7 +4,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms-documentation/src/docbkx/introduction.xml
+++ b/plugin/layer-tms/tms-documentation/src/docbkx/introduction.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms-documentation/src/docbkx/master.xml
+++ b/plugin/layer-tms/tms-documentation/src/docbkx/master.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms-documentation/src/docbkx/master.xml
+++ b/plugin/layer-tms/tms-documentation/src/docbkx/master.xml
@@ -17,7 +17,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2010-2015</year>
+			<year>2010-2016</year>
 
 			<holder>Geosparc nv</holder>
 		</copyright>

--- a/plugin/layer-tms/tms-javadoc/pom.xml
+++ b/plugin/layer-tms/tms-javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/pom.xml
+++ b/plugin/layer-tms/tms/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/TmsConfigurationService.java
+++ b/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/TmsConfigurationService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/TmsLayer.java
+++ b/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/TmsLayer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/TmsLayerException.java
+++ b/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/TmsLayerException.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/mvc/TmsProxyController.java
+++ b/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/mvc/TmsProxyController.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/tile/SimpleTmsUrlBuilder.java
+++ b/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/tile/SimpleTmsUrlBuilder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/tile/TileMapUrlBuilder.java
+++ b/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/tile/TileMapUrlBuilder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/tile/TileService.java
+++ b/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/tile/TileService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/tile/TileServiceState.java
+++ b/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/tile/TileServiceState.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/tile/TileUrlBuilder.java
+++ b/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/tile/TileUrlBuilder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/xml/BoundingBox.java
+++ b/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/xml/BoundingBox.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/xml/Origin.java
+++ b/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/xml/Origin.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/xml/TileFormat.java
+++ b/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/xml/TileFormat.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/xml/TileMap.java
+++ b/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/xml/TileMap.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/xml/TileSet.java
+++ b/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/xml/TileSet.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/xml/TileSets.java
+++ b/plugin/layer-tms/tms/src/main/java/org/geomajas/layer/tms/xml/TileSets.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/resources/META-INF/geomajasContextLayerTms.xml
+++ b/plugin/layer-tms/tms/src/main/resources/META-INF/geomajasContextLayerTms.xml
@@ -39,7 +39,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2011 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>

--- a/plugin/layer-tms/tms/src/main/resources/META-INF/geomajasContextLayerTms.xml
+++ b/plugin/layer-tms/tms/src/main/resources/META-INF/geomajasContextLayerTms.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/resources/META-INF/geomajasWebContextLayerTms.xml
+++ b/plugin/layer-tms/tms/src/main/resources/META-INF/geomajasWebContextLayerTms.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/resources/org/geomajas/layer/tms/TmsLayerException_en.properties
+++ b/plugin/layer-tms/tms/src/main/resources/org/geomajas/layer/tms/TmsLayerException_en.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/main/resources/org/geomajas/layer/tms/TmsLayerException_nl.properties
+++ b/plugin/layer-tms/tms/src/main/resources/org/geomajas/layer/tms/TmsLayerException_nl.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/test/java/org/geomajas/layer/tms/TmsConfigurationTest.java
+++ b/plugin/layer-tms/tms/src/test/java/org/geomajas/layer/tms/TmsConfigurationTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/test/java/org/geomajas/layer/tms/TmsLayerTest.java
+++ b/plugin/layer-tms/tms/src/test/java/org/geomajas/layer/tms/TmsLayerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/test/java/org/geomajas/layer/tms/mvc/TmsControllerTest.java
+++ b/plugin/layer-tms/tms/src/test/java/org/geomajas/layer/tms/mvc/TmsControllerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/test/java/org/geomajas/layer/tms/tile/SimpleTmsUrlBuilderTest.java
+++ b/plugin/layer-tms/tms/src/test/java/org/geomajas/layer/tms/tile/SimpleTmsUrlBuilderTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/test/java/org/geomajas/layer/tms/tile/TileMapUrlBuilderTest.java
+++ b/plugin/layer-tms/tms/src/test/java/org/geomajas/layer/tms/tile/TileMapUrlBuilderTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/test/java/org/geomajas/layer/tms/tile/TileServiceStateTest.java
+++ b/plugin/layer-tms/tms/src/test/java/org/geomajas/layer/tms/tile/TileServiceStateTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/test/java/org/geomajas/layer/tms/tile/TmsTileServiceTest.java
+++ b/plugin/layer-tms/tms/src/test/java/org/geomajas/layer/tms/tile/TmsTileServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/test/resources/logback-test.xml
+++ b/plugin/layer-tms/tms/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-tms/tms/src/test/resources/org/geomajas/layer/tms/tmsContext.xml
+++ b/plugin/layer-tms/tms/src/test/resources/org/geomajas/layer/tms/tmsContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/pom.xml
+++ b/plugin/layer-wms/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms-documentation/pom.xml
+++ b/plugin/layer-wms/wms-documentation/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.plugin</groupId>

--- a/plugin/layer-wms/wms-documentation/pom.xml
+++ b/plugin/layer-wms/wms-documentation/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms-documentation/src/docbkx/configuration.xml
+++ b/plugin/layer-wms/wms-documentation/src/docbkx/configuration.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms-documentation/src/docbkx/howto.xml
+++ b/plugin/layer-wms/wms-documentation/src/docbkx/howto.xml
@@ -4,7 +4,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms-documentation/src/docbkx/introduction.xml
+++ b/plugin/layer-wms/wms-documentation/src/docbkx/introduction.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms-documentation/src/docbkx/master.xml
+++ b/plugin/layer-wms/wms-documentation/src/docbkx/master.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms-documentation/src/docbkx/master.xml
+++ b/plugin/layer-wms/wms-documentation/src/docbkx/master.xml
@@ -17,7 +17,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2010-2015</year>
+			<year>2010-2016</year>
 
 			<holder>Geosparc nv</holder>
 		</copyright>

--- a/plugin/layer-wms/wms-javadoc/pom.xml
+++ b/plugin/layer-wms/wms-javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/pom.xml
+++ b/plugin/layer-wms/wms/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/main/java/org/geomajas/layer/wms/LayerFeatureInfoSupport.java
+++ b/plugin/layer-wms/wms/src/main/java/org/geomajas/layer/wms/LayerFeatureInfoSupport.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/main/java/org/geomajas/layer/wms/WmsAuthentication.java
+++ b/plugin/layer-wms/wms/src/main/java/org/geomajas/layer/wms/WmsAuthentication.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/main/java/org/geomajas/layer/wms/WmsAuthenticationMethod.java
+++ b/plugin/layer-wms/wms/src/main/java/org/geomajas/layer/wms/WmsAuthenticationMethod.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/main/java/org/geomajas/layer/wms/WmsLayer.java
+++ b/plugin/layer-wms/wms/src/main/java/org/geomajas/layer/wms/WmsLayer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/main/java/org/geomajas/layer/wms/command/dto/SearchByPointRequest.java
+++ b/plugin/layer-wms/wms/src/main/java/org/geomajas/layer/wms/command/dto/SearchByPointRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/main/java/org/geomajas/layer/wms/command/dto/SearchByPointResponse.java
+++ b/plugin/layer-wms/wms/src/main/java/org/geomajas/layer/wms/command/dto/SearchByPointResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/main/java/org/geomajas/layer/wms/command/wms/SearchByPointCommand.java
+++ b/plugin/layer-wms/wms/src/main/java/org/geomajas/layer/wms/command/wms/SearchByPointCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/main/java/org/geomajas/layer/wms/mvc/WmsProxyController.java
+++ b/plugin/layer-wms/wms/src/main/java/org/geomajas/layer/wms/mvc/WmsProxyController.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/main/resources/META-INF/geomajasContextLayerWms.xml
+++ b/plugin/layer-wms/wms/src/main/resources/META-INF/geomajasContextLayerWms.xml
@@ -49,7 +49,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2011 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>

--- a/plugin/layer-wms/wms/src/main/resources/META-INF/geomajasContextLayerWms.xml
+++ b/plugin/layer-wms/wms/src/main/resources/META-INF/geomajasContextLayerWms.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/main/resources/META-INF/geomajasWebContextLayerWms.xml
+++ b/plugin/layer-wms/wms/src/main/resources/META-INF/geomajasWebContextLayerWms.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/test/java/org/geomajas/layer/wms/WmsLayerTest.java
+++ b/plugin/layer-wms/wms/src/test/java/org/geomajas/layer/wms/WmsLayerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/test/java/org/geomajas/layer/wms/WmsLayerTileTest.java
+++ b/plugin/layer-wms/wms/src/test/java/org/geomajas/layer/wms/WmsLayerTileTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/test/java/org/geomajas/layer/wms/command/SearchByPointCommandTest.java
+++ b/plugin/layer-wms/wms/src/test/java/org/geomajas/layer/wms/command/SearchByPointCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/test/java/org/geomajas/layer/wms/mvc/WmsControllerCacheTest.java
+++ b/plugin/layer-wms/wms/src/test/java/org/geomajas/layer/wms/mvc/WmsControllerCacheTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/test/java/org/geomajas/layer/wms/mvc/WmsControllerTest.java
+++ b/plugin/layer-wms/wms/src/test/java/org/geomajas/layer/wms/mvc/WmsControllerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/test/resources/logback-test.xml
+++ b/plugin/layer-wms/wms/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/test/resources/wmsContext.xml
+++ b/plugin/layer-wms/wms/src/test/resources/wmsContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/test/resources/wmsContext2.xml
+++ b/plugin/layer-wms/wms/src/test/resources/wmsContext2.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/layer-wms/wms/src/test/resources/wmsInvalidContext.xml
+++ b/plugin/layer-wms/wms/src/test/resources/wmsInvalidContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/print/pom.xml
+++ b/plugin/print/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/print/print-documentation/pom.xml
+++ b/plugin/print/print-documentation/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/print/print-documentation/pom.xml
+++ b/plugin/print/print-documentation/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.plugin</groupId>

--- a/plugin/print/print-documentation/src/docbkx/configuration.xml
+++ b/plugin/print/print-documentation/src/docbkx/configuration.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2013 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/print/print-documentation/src/docbkx/howto.xml
+++ b/plugin/print/print-documentation/src/docbkx/howto.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2013 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/print/print-documentation/src/docbkx/introduction.xml
+++ b/plugin/print/print-documentation/src/docbkx/introduction.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/print/print-documentation/src/docbkx/master.xml
+++ b/plugin/print/print-documentation/src/docbkx/master.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/print/print-documentation/src/docbkx/master.xml
+++ b/plugin/print/print-documentation/src/docbkx/master.xml
@@ -17,7 +17,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2010-2012</year>
+			<year>2010-2016</year>
 
 			<holder>Geosparc nv</holder>
 		</copyright>

--- a/plugin/print/print-javadoc/pom.xml
+++ b/plugin/print/print-javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/print/print/pom.xml
+++ b/plugin/print/print/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/PrintingException.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/PrintingException.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/command/dto/PrintGetTemplateExtRequest.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/command/dto/PrintGetTemplateExtRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/command/dto/PrintGetTemplateExtResponse.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/command/dto/PrintGetTemplateExtResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/command/dto/PrintGetTemplateRequest.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/command/dto/PrintGetTemplateRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/command/dto/PrintGetTemplateResponse.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/command/dto/PrintGetTemplateResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/command/dto/PrintTemplateInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/command/dto/PrintTemplateInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/command/print/LayoutAsSinglePageDoc.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/command/print/LayoutAsSinglePageDoc.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/command/print/PrintGetTemplateCommand.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/command/print/PrintGetTemplateCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/command/print/PrintGetTemplateExtCommand.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/command/print/PrintGetTemplateExtCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/BaseLayerComponent.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/BaseLayerComponent.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/ComponentUtil.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/ComponentUtil.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/LabelComponent.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/LabelComponent.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/LayoutConstraint.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/LayoutConstraint.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/LegendComponent.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/LegendComponent.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/LegendViaUrlComponent.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/LegendViaUrlComponent.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/MapComponent.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/MapComponent.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/PageComponent.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/PageComponent.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/PdfContext.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/PdfContext.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/PrintComponent.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/PrintComponent.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/PrintComponentVisitor.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/PrintComponentVisitor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/ScaleBarComponent.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/ScaleBarComponent.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/TopDownVisitor.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/TopDownVisitor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/ViewPortComponent.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/ViewPortComponent.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/BaseLayerComponentInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/BaseLayerComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/ImageComponentInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/ImageComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/LabelComponentInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/LabelComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/LayoutConstraintInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/LayoutConstraintInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/LegendComponentInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/LegendComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/LegendForLayerComponentInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/LegendForLayerComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/LegendGraphicComponentInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/LegendGraphicComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/LegendIconComponentInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/LegendIconComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/LegendItemComponentInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/LegendItemComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/LegendViaUrlComponentInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/LegendViaUrlComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/MapComponentInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/MapComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/PageComponentInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/PageComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/PrintComponentInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/PrintComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/RasterLayerComponentInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/RasterLayerComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/RasterizedLayersComponentInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/RasterizedLayersComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/ScaleBarComponentInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/ScaleBarComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/VectorLayerComponentInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/VectorLayerComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/ViewPortComponentInfo.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/dto/ViewPortComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/AbstractPrintComponent.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/AbstractPrintComponent.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/BaseLayerComponentImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/BaseLayerComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/ImageComponentImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/ImageComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/LabelComponentImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/LabelComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/LegendComponentImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/LegendComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/LegendForLayerComponentImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/LegendForLayerComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/LegendGraphicComponentImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/LegendGraphicComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/LegendIconComponentImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/LegendIconComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/LegendItemComponentImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/LegendItemComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/LegendViaUrlComponentImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/LegendViaUrlComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/MapComponentImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/MapComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/PageComponentImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/PageComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/PrintComponentImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/PrintComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/RasterLayerComponentImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/RasterLayerComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/RasterizedLayersComponentImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/RasterizedLayersComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/ScaleBarComponentImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/ScaleBarComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/VectorLayerComponentImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/VectorLayerComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/ViewPortComponentImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/impl/ViewPortComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/service/PrintConfigurationService.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/service/PrintConfigurationService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/service/PrintConfigurationServiceImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/service/PrintConfigurationServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/service/PrintDtoConverterService.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/service/PrintDtoConverterService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/service/PrintDtoConverterServiceImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/component/service/PrintDtoConverterServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/configuration/DefaultConfigurationVisitor.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/configuration/DefaultConfigurationVisitor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/configuration/HibernatePrintTemplateDao.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/configuration/HibernatePrintTemplateDao.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/configuration/InMemoryPrintTemplateDao.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/configuration/InMemoryPrintTemplateDao.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/configuration/MapConfigurationVisitor.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/configuration/MapConfigurationVisitor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/configuration/PrintConfiguration.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/configuration/PrintConfiguration.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/configuration/PrintTemplate.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/configuration/PrintTemplate.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/configuration/PrintTemplateDao.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/configuration/PrintTemplateDao.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/document/AbstractDocument.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/document/AbstractDocument.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/document/DefaultDocument.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/document/DefaultDocument.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/document/Document.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/document/Document.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/document/SinglePageDocument.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/document/SinglePageDocument.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/mvc/DocumentView.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/mvc/DocumentView.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/mvc/PrintingController.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/mvc/PrintingController.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/mvc/SecurityInterceptor.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/mvc/SecurityInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/mvc/TypeInfoMixin.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/mvc/TypeInfoMixin.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/parser/ColorConverter.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/parser/ColorConverter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/parser/FontConverter.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/parser/FontConverter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/parser/PrettyPrintDriver.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/parser/PrettyPrintDriver.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/parser/RectangleConverter.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/parser/RectangleConverter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/service/PrintService.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/service/PrintService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/java/org/geomajas/plugin/printing/service/PrintServiceImpl.java
+++ b/plugin/print/print/src/main/java/org/geomajas/plugin/printing/service/PrintServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/resources/META-INF/geomajasContextPrint.xml
+++ b/plugin/print/print/src/main/resources/META-INF/geomajasContextPrint.xml
@@ -39,7 +39,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2011 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>

--- a/plugin/print/print/src/main/resources/META-INF/geomajasContextPrint.xml
+++ b/plugin/print/print/src/main/resources/META-INF/geomajasContextPrint.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/resources/META-INF/geomajasWebContextPrint.xml
+++ b/plugin/print/print/src/main/resources/META-INF/geomajasWebContextPrint.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/resources/org/geomajas/extension/printing/rasterlayercomponent.properties
+++ b/plugin/print/print/src/main/resources/org/geomajas/extension/printing/rasterlayercomponent.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/resources/org/geomajas/extension/printing/rasterlayercomponent_nl.properties
+++ b/plugin/print/print/src/main/resources/org/geomajas/extension/printing/rasterlayercomponent_nl.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/resources/org/geomajas/plugin/printing/PrintingException.properties
+++ b/plugin/print/print/src/main/resources/org/geomajas/plugin/printing/PrintingException.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/resources/org/geomajas/plugin/printing/PrintingException_nl.properties
+++ b/plugin/print/print/src/main/resources/org/geomajas/plugin/printing/PrintingException_nl.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/resources/org/geomajas/plugin/printing/PrintingMessages.properties
+++ b/plugin/print/print/src/main/resources/org/geomajas/plugin/printing/PrintingMessages.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/resources/org/geomajas/plugin/printing/PrintingMessages_en.properties
+++ b/plugin/print/print/src/main/resources/org/geomajas/plugin/printing/PrintingMessages_en.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/resources/org/geomajas/plugin/printing/PrintingMessages_en_US.properties
+++ b/plugin/print/print/src/main/resources/org/geomajas/plugin/printing/PrintingMessages_en_US.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/main/resources/org/geomajas/plugin/printing/PrintingMessages_nl.properties
+++ b/plugin/print/print/src/main/resources/org/geomajas/plugin/printing/PrintingMessages_nl.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/test/java/org/geomajas/plugin/printing/component/ComponentUtilTest.java
+++ b/plugin/print/print/src/test/java/org/geomajas/plugin/printing/component/ComponentUtilTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/test/java/org/geomajas/plugin/printing/component/DummyComponent.java
+++ b/plugin/print/print/src/test/java/org/geomajas/plugin/printing/component/DummyComponent.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/test/java/org/geomajas/plugin/printing/component/dto/DummyComponentInfo.java
+++ b/plugin/print/print/src/test/java/org/geomajas/plugin/printing/component/dto/DummyComponentInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/test/java/org/geomajas/plugin/printing/component/impl/BaseComponentImplTest.java
+++ b/plugin/print/print/src/test/java/org/geomajas/plugin/printing/component/impl/BaseComponentImplTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/test/java/org/geomajas/plugin/printing/component/impl/DummyComponentImpl.java
+++ b/plugin/print/print/src/test/java/org/geomajas/plugin/printing/component/impl/DummyComponentImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/test/java/org/geomajas/plugin/printing/component/service/PrintDtoConverterServiceTest.java
+++ b/plugin/print/print/src/test/java/org/geomajas/plugin/printing/component/service/PrintDtoConverterServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/test/java/org/geomajas/plugin/printing/document/DefaultDocumentTest.java
+++ b/plugin/print/print/src/test/java/org/geomajas/plugin/printing/document/DefaultDocumentTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/test/java/org/geomajas/plugin/printing/mvc/TestTemplateBuilder.java
+++ b/plugin/print/print/src/test/java/org/geomajas/plugin/printing/mvc/TestTemplateBuilder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/test/java/org/geomajas/plugin/printing/service/PrintServiceImplTest.java
+++ b/plugin/print/print/src/test/java/org/geomajas/plugin/printing/service/PrintServiceImplTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/test/resources/logback-test.xml
+++ b/plugin/print/print/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/test/resources/org/geomajas/configuration/applications/simplevectors/simplevectorsContext.xml
+++ b/plugin/print/print/src/test/resources/org/geomajas/configuration/applications/simplevectors/simplevectorsContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/print/print/src/test/resources/org/geomajas/plugin/printing/printing.xml
+++ b/plugin/print/print/src/test/resources/org/geomajas/plugin/printing/printing.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/profiling/pom.xml
+++ b/plugin/profiling/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/profiling/profiling-documentation/pom.xml
+++ b/plugin/profiling/profiling-documentation/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/profiling/profiling-documentation/pom.xml
+++ b/plugin/profiling/profiling-documentation/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.plugin</groupId>

--- a/plugin/profiling/profiling-documentation/src/docbkx/configuration.xml
+++ b/plugin/profiling/profiling-documentation/src/docbkx/configuration.xml
@@ -4,7 +4,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/profiling/profiling-documentation/src/docbkx/howto.xml
+++ b/plugin/profiling/profiling-documentation/src/docbkx/howto.xml
@@ -4,7 +4,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/profiling/profiling-documentation/src/docbkx/introduction.xml
+++ b/plugin/profiling/profiling-documentation/src/docbkx/introduction.xml
@@ -4,7 +4,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/profiling/profiling-documentation/src/docbkx/master.xml
+++ b/plugin/profiling/profiling-documentation/src/docbkx/master.xml
@@ -16,7 +16,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2011</year>
+			<year>2011-2016</year>
 
 			<holder>Geosparc nv</holder>
 		</copyright>

--- a/plugin/profiling/profiling-documentation/src/docbkx/master.xml
+++ b/plugin/profiling/profiling-documentation/src/docbkx/master.xml
@@ -4,7 +4,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/profiling/profiling-javadoc/pom.xml
+++ b/plugin/profiling/profiling-javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/profiling/profiling/pom.xml
+++ b/plugin/profiling/profiling/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/profiling/profiling/src/main/java/org/geomajas/plugin/profiling/aop/CommandProfilingInterceptor.java
+++ b/plugin/profiling/profiling/src/main/java/org/geomajas/plugin/profiling/aop/CommandProfilingInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/profiling/profiling/src/main/java/org/geomajas/plugin/profiling/aop/LayerProfilingAdvisor.java
+++ b/plugin/profiling/profiling/src/main/java/org/geomajas/plugin/profiling/aop/LayerProfilingAdvisor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/profiling/profiling/src/main/java/org/geomajas/plugin/profiling/aop/LayerProfilingInterceptor.java
+++ b/plugin/profiling/profiling/src/main/java/org/geomajas/plugin/profiling/aop/LayerProfilingInterceptor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/profiling/profiling/src/main/resources/META-INF/geomajasContextProfiling.xml
+++ b/plugin/profiling/profiling/src/main/resources/META-INF/geomajasContextProfiling.xml
@@ -36,7 +36,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2015 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>

--- a/plugin/profiling/profiling/src/main/resources/META-INF/geomajasContextProfiling.xml
+++ b/plugin/profiling/profiling/src/main/resources/META-INF/geomajasContextProfiling.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/profiling/profiling/src/test/java/org/geomajas/plugin/profiling/aop/CommandProfilingTest.java
+++ b/plugin/profiling/profiling/src/test/java/org/geomajas/plugin/profiling/aop/CommandProfilingTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/profiling/profiling/src/test/java/org/geomajas/plugin/profiling/aop/LayerProfilingTest.java
+++ b/plugin/profiling/profiling/src/test/java/org/geomajas/plugin/profiling/aop/LayerProfilingTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/profiling/profiling/src/test/resources/logback-test.xml
+++ b/plugin/profiling/profiling/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/pom.xml
+++ b/plugin/rasterizing/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing-documentation/pom.xml
+++ b/plugin/rasterizing/rasterizing-documentation/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.plugin</groupId>

--- a/plugin/rasterizing/rasterizing-documentation/pom.xml
+++ b/plugin/rasterizing/rasterizing-documentation/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2013 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing-documentation/src/docbkx/configuration.xml
+++ b/plugin/rasterizing/rasterizing-documentation/src/docbkx/configuration.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2013 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing-documentation/src/docbkx/controllers.xml
+++ b/plugin/rasterizing/rasterizing-documentation/src/docbkx/controllers.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2013 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing-documentation/src/docbkx/howto.xml
+++ b/plugin/rasterizing/rasterizing-documentation/src/docbkx/howto.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2013 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing-documentation/src/docbkx/introduction.xml
+++ b/plugin/rasterizing/rasterizing-documentation/src/docbkx/introduction.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2013 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing-documentation/src/docbkx/master.xml
+++ b/plugin/rasterizing/rasterizing-documentation/src/docbkx/master.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2013 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered
@@ -17,7 +17,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2010-2012</year>
+			<year>2010-2016</year>
 
 			<holder>Geosparc nv</holder>
 		</copyright>

--- a/plugin/rasterizing/rasterizing-javadoc/pom.xml
+++ b/plugin/rasterizing/rasterizing-javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/pom.xml
+++ b/plugin/rasterizing/rasterizing/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/ImageServiceImpl.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/ImageServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/LayerFactoryServiceImpl.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/LayerFactoryServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/RenderingServiceImpl.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/RenderingServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/api/ImageService.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/api/ImageService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/api/LayerFactory.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/api/LayerFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/api/LayerFactoryService.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/api/LayerFactoryService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/api/RasterException.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/api/RasterException.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/api/RasterizingContainer.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/api/RasterizingContainer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/api/RasterizingEnvironmentVariable.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/api/RasterizingEnvironmentVariable.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/api/RasterizingPipelineCode.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/api/RasterizingPipelineCode.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/api/RenderingService.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/api/RenderingService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/ClientGeometryLayerInfo.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/ClientGeometryLayerInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/ClientSvgLayerInfo.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/ClientSvgLayerInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/ClientWorldPaintableLayerInfo.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/ClientWorldPaintableLayerInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/LegendRasterizingInfo.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/LegendRasterizingInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/MapRasterizingInfo.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/MapRasterizingInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/RasterLayerRasterizingInfo.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/RasterLayerRasterizingInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/RasterizeMapRequest.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/RasterizeMapRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/RasterizeMapResponse.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/RasterizeMapResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/RasterizingConstants.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/RasterizingConstants.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/VectorLayerRasterizingInfo.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/VectorLayerRasterizingInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/WorldEllipseInfo.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/WorldEllipseInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/WorldGeometryInfo.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/WorldGeometryInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/WorldImageInfo.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/WorldImageInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/WorldPaintableInfo.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/WorldPaintableInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/WorldRectangleInfo.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/WorldRectangleInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/WorldTextInfo.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/dto/WorldTextInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/rasterizing/RasterizeMapCommand.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/command/rasterizing/RasterizeMapCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/GeometryDirectLayer.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/GeometryDirectLayer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/GeometryLayerFactory.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/GeometryLayerFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/InternalFeatureCollection.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/InternalFeatureCollection.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/RasterDirectLayer.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/RasterDirectLayer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/RasterLayerFactory.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/RasterLayerFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/SvgDirectLayer.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/SvgDirectLayer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/SvgLayerFactory.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/SvgLayerFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/VectorLayerFactory.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/VectorLayerFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/WorldPaintableDirectLayer.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/WorldPaintableDirectLayer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/WorldPaintableLayerFactory.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/WorldPaintableLayerFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/tile/TmsTileMetadata.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/layer/tile/TmsTileMetadata.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/legend/LegendBuilder.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/legend/LegendBuilder.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/legend/RenderedImageIcon.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/legend/RenderedImageIcon.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/mvc/RasterizingController.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/mvc/RasterizingController.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/mvc/TmsController.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/mvc/TmsController.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/sld/SymbolizerFilterVisitor.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/sld/SymbolizerFilterVisitor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/AbstractRasterizingStep.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/AbstractRasterizingStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/AddLayersStep.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/AddLayersStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/ClearPanOriginStep.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/ClearPanOriginStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/RasterCachePutStep.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/RasterCachePutStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/RasterTileStep.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/RasterTileStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/RasterUrlStep.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/RasterUrlStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/RebuildCacheContainer.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/RebuildCacheContainer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/RebuildCachePutStep.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/RebuildCachePutStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/RenderLegendStep.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/RenderLegendStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/RenderMapStep.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/RenderMapStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/WriteImageStep.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/step/WriteImageStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/BoundingBox.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/BoundingBox.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/GlobalGeodeticProfile.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/GlobalGeodeticProfile.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/GlobalMercatorProfile.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/GlobalMercatorProfile.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/LocalProfile.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/LocalProfile.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/Origin.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/Origin.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/ProfileType.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/ProfileType.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TileFormat.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TileFormat.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TileMap.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TileMap.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TileMapRef.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TileMapRef.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TileMapService.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TileMapService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TileSet.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TileSet.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TileSets.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TileSets.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TmsProfile.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TmsProfile.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TmsService.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TmsService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TmsServiceImpl.java
+++ b/plugin/rasterizing/rasterizing/src/main/java/org/geomajas/plugin/rasterizing/tms/TmsServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/resources/META-INF/geomajasContextRasterizing.xml
+++ b/plugin/rasterizing/rasterizing/src/main/resources/META-INF/geomajasContextRasterizing.xml
@@ -39,7 +39,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2011 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>

--- a/plugin/rasterizing/rasterizing/src/main/resources/META-INF/geomajasContextRasterizing.xml
+++ b/plugin/rasterizing/rasterizing/src/main/resources/META-INF/geomajasContextRasterizing.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/resources/META-INF/geomajasWebContextRasterizing.xml
+++ b/plugin/rasterizing/rasterizing/src/main/resources/META-INF/geomajasWebContextRasterizing.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/resources/org/geomajas/plugin/rasterizing/DefaultCachedAndRasterizedPipelines.xml
+++ b/plugin/rasterizing/rasterizing/src/main/resources/org/geomajas/plugin/rasterizing/DefaultCachedAndRasterizedPipelines.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/main/resources/org/geomajas/plugin/rasterizing/DefaultRasterizedPipelines.xml
+++ b/plugin/rasterizing/rasterizing/src/main/resources/org/geomajas/plugin/rasterizing/DefaultRasterizedPipelines.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/test/java/org/geomajas/plugin/rasterizing/RasterizingPipelineTest.java
+++ b/plugin/rasterizing/rasterizing/src/test/java/org/geomajas/plugin/rasterizing/RasterizingPipelineTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/test/java/org/geomajas/plugin/rasterizing/StyleUtil.java
+++ b/plugin/rasterizing/rasterizing/src/test/java/org/geomajas/plugin/rasterizing/StyleUtil.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/test/java/org/geomajas/plugin/rasterizing/command/RasterizeMapCommandTest.java
+++ b/plugin/rasterizing/rasterizing/src/test/java/org/geomajas/plugin/rasterizing/command/RasterizeMapCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/test/resources/logback-test.xml
+++ b/plugin/rasterizing/rasterizing/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/rasterizing/rasterizing/src/test/resources/org/geomajas/plugin/rasterizing/rasterizing-service.xml
+++ b/plugin/rasterizing/rasterizing/src/test/resources/org/geomajas/plugin/rasterizing/rasterizing-service.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/reporting/pom.xml
+++ b/plugin/reporting/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting-documentation/pom.xml
+++ b/plugin/reporting/reporting-documentation/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting-documentation/pom.xml
+++ b/plugin/reporting/reporting-documentation/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.plugin</groupId>

--- a/plugin/reporting/reporting-documentation/src/docbkx/configuration.xml
+++ b/plugin/reporting/reporting-documentation/src/docbkx/configuration.xml
@@ -4,7 +4,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting-documentation/src/docbkx/howto.xml
+++ b/plugin/reporting/reporting-documentation/src/docbkx/howto.xml
@@ -4,7 +4,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting-documentation/src/docbkx/introduction.xml
+++ b/plugin/reporting/reporting-documentation/src/docbkx/introduction.xml
@@ -4,7 +4,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting-documentation/src/docbkx/master.xml
+++ b/plugin/reporting/reporting-documentation/src/docbkx/master.xml
@@ -16,7 +16,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2010-2015</year>
+			<year>2010-2016</year>
 
 			<holder>Geosparc nv</holder>
 		</copyright>

--- a/plugin/reporting/reporting-documentation/src/docbkx/master.xml
+++ b/plugin/reporting/reporting-documentation/src/docbkx/master.xml
@@ -4,7 +4,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting-javadoc/pom.xml
+++ b/plugin/reporting/reporting-javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/pom.xml
+++ b/plugin/reporting/reporting/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/ReportingException.java
+++ b/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/ReportingException.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/command/dto/PrepareReportingRequest.java
+++ b/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/command/dto/PrepareReportingRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/command/dto/PrepareReportingResponse.java
+++ b/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/command/dto/PrepareReportingResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/command/reporting/PrepareReportingCommand.java
+++ b/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/command/reporting/PrepareReportingCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/data/InternalFeatureDataSource.java
+++ b/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/data/InternalFeatureDataSource.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/data/ReportingCacheContainer.java
+++ b/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/data/ReportingCacheContainer.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/mvc/JasperReportsDocxView.java
+++ b/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/mvc/JasperReportsDocxView.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/mvc/JasperReportsOdtView.java
+++ b/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/mvc/JasperReportsOdtView.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/mvc/PrintParameterConversionService.java
+++ b/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/mvc/PrintParameterConversionService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/mvc/ReportingController.java
+++ b/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/mvc/ReportingController.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/mvc/StringToEnvelopeConverter.java
+++ b/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/mvc/StringToEnvelopeConverter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/mvc/StringToStringArrayConverter.java
+++ b/plugin/reporting/reporting/src/main/java/org/geomajas/plugin/reporting/mvc/StringToStringArrayConverter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/main/resources/META-INF/geomajasContextReporting.xml
+++ b/plugin/reporting/reporting/src/main/resources/META-INF/geomajasContextReporting.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/main/resources/META-INF/geomajasWebContextReporting.xml
+++ b/plugin/reporting/reporting/src/main/resources/META-INF/geomajasWebContextReporting.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/main/resources/org/geomajas/plugin/reporting/ReportingException.properties
+++ b/plugin/reporting/reporting/src/main/resources/org/geomajas/plugin/reporting/ReportingException.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/main/resources/org/geomajas/plugin/reporting/ReportingException_nl.properties
+++ b/plugin/reporting/reporting/src/main/resources/org/geomajas/plugin/reporting/ReportingException_nl.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/test/resources/logback-test.xml
+++ b/plugin/reporting/reporting/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/reporting/reporting/src/test/resources/org/geomajas/plugin/reporting/security.xml
+++ b/plugin/reporting/reporting/src/test/resources/org/geomajas/plugin/reporting/security.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/pom.xml
+++ b/plugin/runtimeconfig/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig-documentation/pom.xml
+++ b/plugin/runtimeconfig/runtimeconfig-documentation/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig-documentation/pom.xml
+++ b/plugin/runtimeconfig/runtimeconfig-documentation/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.plugin</groupId>

--- a/plugin/runtimeconfig/runtimeconfig-documentation/src/docbkx/configuration.xml
+++ b/plugin/runtimeconfig/runtimeconfig-documentation/src/docbkx/configuration.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig-documentation/src/docbkx/howto.xml
+++ b/plugin/runtimeconfig/runtimeconfig-documentation/src/docbkx/howto.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig-documentation/src/docbkx/introduction.xml
+++ b/plugin/runtimeconfig/runtimeconfig-documentation/src/docbkx/introduction.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig-documentation/src/docbkx/master.xml
+++ b/plugin/runtimeconfig/runtimeconfig-documentation/src/docbkx/master.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig-documentation/src/docbkx/master.xml
+++ b/plugin/runtimeconfig/runtimeconfig-documentation/src/docbkx/master.xml
@@ -17,7 +17,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2010-2015</year>
+			<year>2010-2016</year>
 
 			<holder>Geosparc nv</holder>
 		</copyright>

--- a/plugin/runtimeconfig/runtimeconfig-documentation/src/docbkx/use.xml
+++ b/plugin/runtimeconfig/runtimeconfig-documentation/src/docbkx/use.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig-javadoc/pom.xml
+++ b/plugin/runtimeconfig/runtimeconfig-javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/pom.xml
+++ b/plugin/runtimeconfig/runtimeconfig/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/. 
-	~ ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium. ~
+	~ ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium. ~
 	~ The program is available in open source according to the GNU Affero ~ General 
 	Public License. All contributions in this program are covered ~ by the Geomajas 
 	Contributors License Agreement. For full licensing ~ details, see LICENSE.txt 

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/RuntimeConfigException.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/RuntimeConfigException.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/dto/DestroyBeanConfigurationRequest.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/dto/DestroyBeanConfigurationRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/dto/DestroyBeanConfigurationResponse.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/dto/DestroyBeanConfigurationResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/dto/ListBeansOfTypeRequest.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/dto/ListBeansOfTypeRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/dto/ListBeansOfTypeResponse.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/dto/ListBeansOfTypeResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/dto/SaveOrUpdateBeanConfigurationRequest.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/dto/SaveOrUpdateBeanConfigurationRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/dto/SaveOrUpdateBeanConfigurationResponse.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/dto/SaveOrUpdateBeanConfigurationResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/dto/SaveOrUpdateParameterBeanRequest.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/dto/SaveOrUpdateParameterBeanRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/dto/SaveOrUpdateParameterBeanResponse.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/dto/SaveOrUpdateParameterBeanResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/runtimeconfig/DestroyBeanConfigurationCommand.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/runtimeconfig/DestroyBeanConfigurationCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/runtimeconfig/ListBeansOfTypeCommand.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/runtimeconfig/ListBeansOfTypeCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/runtimeconfig/SaveOrUpdateBeanConfigurationCommand.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/runtimeconfig/SaveOrUpdateBeanConfigurationCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/runtimeconfig/SaveOrUpdateParameterBeanCommand.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/command/runtimeconfig/SaveOrUpdateParameterBeanCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/BeanConfigurationInfo.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/BeanConfigurationInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/BeanDefinitionHolderInfo.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/BeanDefinitionHolderInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/BeanDefinitionInfo.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/BeanDefinitionInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/BeanMetadataElementInfo.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/BeanMetadataElementInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/BeanReferenceInfo.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/BeanReferenceInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/BeanTypeInfo.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/BeanTypeInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/GenericBeanDefinitionInfo.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/GenericBeanDefinitionInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/ManagedListInfo.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/ManagedListInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/ManagedMapInfo.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/ManagedMapInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/ManagedSetInfo.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/ManagedSetInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/ObjectBeanDefinitionInfo.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/ObjectBeanDefinitionInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/TypedStringInfo.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/bean/TypedStringInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/parameter/ListParameterDto.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/parameter/ListParameterDto.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/parameter/ObjectParameterDto.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/parameter/ObjectParameterDto.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/parameter/ParameterDto.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/parameter/ParameterDto.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/parameter/StringParameterDto.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/dto/parameter/StringParameterDto.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/BeanDefinitionDtoConverterService.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/BeanDefinitionDtoConverterService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/BeanDefinitionDtoConverterServiceImpl.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/BeanDefinitionDtoConverterServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/BeanDefinitionWriterService.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/BeanDefinitionWriterService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/BeanDefinitionWriterServiceImpl.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/BeanDefinitionWriterServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/BeanFactory.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/BeanFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/BeanFactoryService.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/BeanFactoryService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/BeanFactoryServiceImpl.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/BeanFactoryServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/ContextConfiguratorService.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/ContextConfiguratorService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/ContextConfiguratorServiceImpl.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/ContextConfiguratorServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/IdentityFactory.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/IdentityFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/LayerFactory.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/LayerFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/LayerFactoryService.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/LayerFactoryService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/LayerFactoryServiceImpl.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/LayerFactoryServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/RasterLayerFactory.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/RasterLayerFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/Rewirable.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/Rewirable.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/VectorLayerFactory.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/VectorLayerFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/converter/BboxToBeanDefinitionConverter.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/converter/BboxToBeanDefinitionConverter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/converter/ScaleInfoToBeanDefinitionConverter.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/converter/ScaleInfoToBeanDefinitionConverter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/factory/BaseBeanFactory.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/factory/BaseBeanFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/factory/BaseClientLayerBeanFactory.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/factory/BaseClientLayerBeanFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/factory/BaseRasterLayerBeanFactory.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/factory/BaseRasterLayerBeanFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/factory/BaseVectorLayerBeanFactory.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/factory/BaseVectorLayerBeanFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/factory/ClientRasterLayerBeanFactory.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/factory/ClientRasterLayerBeanFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/factory/ClientVectorLayerBeanFactory.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/factory/ClientVectorLayerBeanFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/factory/GeoToolsLayerBeanFactory.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/factory/GeoToolsLayerBeanFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/factory/WmsLayerBeanFactory.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/java/org/geomajas/plugin/runtimeconfig/service/factory/WmsLayerBeanFactory.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/resources/META-INF/geomajasContextRuntimeconfig.xml
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/resources/META-INF/geomajasContextRuntimeconfig.xml
@@ -41,7 +41,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2011 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>

--- a/plugin/runtimeconfig/runtimeconfig/src/main/resources/META-INF/geomajasContextRuntimeconfig.xml
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/resources/META-INF/geomajasContextRuntimeconfig.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/resources/org/geomajas/plugin/runtimeconfig/RuntimeConfigException.properties
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/resources/org/geomajas/plugin/runtimeconfig/RuntimeConfigException.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/resources/org/geomajas/plugin/runtimeconfig/RuntimeConfigException_en.properties
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/resources/org/geomajas/plugin/runtimeconfig/RuntimeConfigException_en.properties
@@ -1,7 +1,7 @@
 #
 # This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
 #
-# Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+# Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
 #
 # The program is available in open source according to the GNU Affero
 # General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/main/resources/org/geomajas/plugin/runtimeconfig/service/rewireConfig.xml
+++ b/plugin/runtimeconfig/runtimeconfig/src/main/resources/org/geomajas/plugin/runtimeconfig/service/rewireConfig.xml
@@ -5,7 +5,7 @@
 		the ~ display, analysis and management of geographic information. ~ It
 		is a building block that allows developers to add maps ~ and other
 		geographic data capabilities to their web applications. ~ ~ Copyright
-		2008-2015 Geosparc, http://www.geosparc.com, Belgium ~ ~ This program
+		2008-2016 Geosparc, http://www.geosparc.com, Belgium ~ ~ This program
 		is free software: you can redistribute it and/or modify ~ it under the
 		terms of the GNU Affero General Public License as ~ published by the
 		Free Software Foundation, either version 3 of the ~ License, or (at

--- a/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/AutowiredBean.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/AutowiredBean.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/BeanDefinitionDtoConverterTest.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/BeanDefinitionDtoConverterTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/BeanDefinitionWriterServiceTest.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/BeanDefinitionWriterServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/ContextConfiguratorServiceTest.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/ContextConfiguratorServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/ConvertTestBean.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/ConvertTestBean.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/LifeCycleBean.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/LifeCycleBean.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/MultiRefreshContextLoader.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/MultiRefreshContextLoader.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/TestEnum.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/TestEnum.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/TestRewirable.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/TestRewirable.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/TestRewirablePostProcessor.java
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/java/org/geomajas/plugin/runtimeconfig/service/TestRewirablePostProcessor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/resources/logback-test.xml
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/command/runtimeconfig/appRuntimeConfig.xml
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/command/runtimeconfig/appRuntimeConfig.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/command/runtimeconfig/mapRuntimeConfig.xml
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/command/runtimeconfig/mapRuntimeConfig.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/command/runtimeconfig/runtimeConfig.xml
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/command/runtimeconfig/runtimeConfig.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/ContextA.xml
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/ContextA.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/ContextABC.xml
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/ContextABC.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/ContextB.xml
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/ContextB.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/ContextBadBean.xml
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/ContextBadBean.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/ContextBadDefinition.xml
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/ContextBadDefinition.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/ContextC.xml
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/ContextC.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/ContextConfiguratorService.xml
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/ContextConfiguratorService.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/TestBeanFactoryService.xml
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/TestBeanFactoryService.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/TestRewireContext.xml
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/TestRewireContext.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/converter/ContextA.xml
+++ b/plugin/runtimeconfig/runtimeconfig/src/test/resources/org/geomajas/plugin/runtimeconfig/service/converter/ContextA.xml
@@ -3,7 +3,7 @@
 	~ rich Internet applications (RIA) with sophisticated capabilities for the 
 	~ display, analysis and management of geographic information. ~ It is a building 
 	block that allows developers to add maps ~ and other geographic data capabilities 
-	to their web applications. ~ ~ Copyright 2008-2015 Geosparc, http://www.geosparc.com,
+	to their web applications. ~ ~ Copyright 2008-2016 Geosparc, http://www.geosparc.com,
 	Belgium ~ ~ This program is free software: you can redistribute it and/or 
 	modify ~ it under the terms of the GNU Affero General Public License as ~ 
 	published by the Free Software Foundation, either version 3 of the ~ License, 

--- a/plugin/staticsecurity/pom.xml
+++ b/plugin/staticsecurity/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity-documentation/pom.xml
+++ b/plugin/staticsecurity/staticsecurity-documentation/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity-documentation/pom.xml
+++ b/plugin/staticsecurity/staticsecurity-documentation/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.plugin</groupId>

--- a/plugin/staticsecurity/staticsecurity-documentation/src/docbkx/configuration.xml
+++ b/plugin/staticsecurity/staticsecurity-documentation/src/docbkx/configuration.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2013 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity-documentation/src/docbkx/howto.xml
+++ b/plugin/staticsecurity/staticsecurity-documentation/src/docbkx/howto.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2013 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity-documentation/src/docbkx/introduction.xml
+++ b/plugin/staticsecurity/staticsecurity-documentation/src/docbkx/introduction.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity-documentation/src/docbkx/master.xml
+++ b/plugin/staticsecurity/staticsecurity-documentation/src/docbkx/master.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity-documentation/src/docbkx/master.xml
+++ b/plugin/staticsecurity/staticsecurity-documentation/src/docbkx/master.xml
@@ -17,7 +17,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2010-2015</year>
+			<year>2010-2016</year>
 
 			<holder>Geosparc nv</holder>
 		</copyright>

--- a/plugin/staticsecurity/staticsecurity-javadoc/pom.xml
+++ b/plugin/staticsecurity/staticsecurity-javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity-ldap/pom.xml
+++ b/plugin/staticsecurity/staticsecurity-ldap/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity-ldap/src/main/java/org/geomajas/plugin/staticsecurity/ldap/LdapAuthenticationService.java
+++ b/plugin/staticsecurity/staticsecurity-ldap/src/main/java/org/geomajas/plugin/staticsecurity/ldap/LdapAuthenticationService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity-ldap/src/main/resources/META-INF/geomajasContextStaticSecurityLdap.xml
+++ b/plugin/staticsecurity/staticsecurity-ldap/src/main/resources/META-INF/geomajasContextStaticSecurityLdap.xml
@@ -40,13 +40,13 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2011 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="UnboundID"/>
-					<property name="copyright" value="(c) 2008-2011 UnboundID Corp."/>
+					<property name="copyright" value="(c) 2008-2016 UnboundID Corp."/>
 					<property name="licenseName" value="GNU Lesser General Public License, version 2.1" />
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/lgpl-2.1.html" />
 				</bean>

--- a/plugin/staticsecurity/staticsecurity-ldap/src/main/resources/META-INF/geomajasContextStaticSecurityLdap.xml
+++ b/plugin/staticsecurity/staticsecurity-ldap/src/main/resources/META-INF/geomajasContextStaticSecurityLdap.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity-ldap/src/test/java/org/geomajas/plugin/staticsecurity/ldap/LdapAuthenticationServiceTest.java
+++ b/plugin/staticsecurity/staticsecurity-ldap/src/test/java/org/geomajas/plugin/staticsecurity/ldap/LdapAuthenticationServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity-ldap/src/test/java/org/geomajas/plugin/staticsecurity/ldap/LdapLoginTest.java
+++ b/plugin/staticsecurity/staticsecurity-ldap/src/test/java/org/geomajas/plugin/staticsecurity/ldap/LdapLoginTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity-ldap/src/test/java/org/geomajas/plugin/staticsecurity/ldap/LdapServerProvider.java
+++ b/plugin/staticsecurity/staticsecurity-ldap/src/test/java/org/geomajas/plugin/staticsecurity/ldap/LdapServerProvider.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity-ldap/src/test/java/org/geomajas/plugin/staticsecurity/ldap/LdapTest.java
+++ b/plugin/staticsecurity/staticsecurity-ldap/src/test/java/org/geomajas/plugin/staticsecurity/ldap/LdapTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity-ldap/src/test/resources/logback-test.xml
+++ b/plugin/staticsecurity/staticsecurity-ldap/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity-ldap/src/test/resources/org/geomajas/plugin/staticsecurity/ldap/ldapConnection.xml
+++ b/plugin/staticsecurity/staticsecurity-ldap/src/test/resources/org/geomajas/plugin/staticsecurity/ldap/ldapConnection.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/pom.xml
+++ b/plugin/staticsecurity/staticsecurity/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/dto/GetUsersRequest.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/dto/GetUsersRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/dto/GetUsersResponse.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/dto/GetUsersResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/dto/LoginRequest.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/dto/LoginRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/dto/LoginResponse.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/dto/LoginResponse.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/dto/LogoutRequest.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/dto/LogoutRequest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/staticsecurity/Base64.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/staticsecurity/Base64.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/staticsecurity/GetUsersCommand.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/staticsecurity/GetUsersCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/staticsecurity/LoginCommand.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/staticsecurity/LoginCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/staticsecurity/LogoutCommand.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/command/staticsecurity/LogoutCommand.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/AreaAuthorizationInfo.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/AreaAuthorizationInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/AttributeAuthorizationInfo.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/AttributeAuthorizationInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/AuthorizationInfo.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/AuthorizationInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/FeatureAuthorizationInfo.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/FeatureAuthorizationInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/LayerAreaAuthorizationInfo.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/LayerAreaAuthorizationInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/LayerAttributeAuthorizationInfo.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/LayerAttributeAuthorizationInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/LayerAuthorization.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/LayerAuthorization.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/LayerAuthorizationInfo.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/LayerAuthorizationInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/LayerFeatureAuthorizationInfo.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/LayerFeatureAuthorizationInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/LayerFilterAuthorizationInfo.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/LayerFilterAuthorizationInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/NamedRoleInfo.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/NamedRoleInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/RoleInfo.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/RoleInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/SecurityServiceInfo.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/SecurityServiceInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/UserInfo.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/configuration/UserInfo.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/AuthenticationService.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/AuthenticationService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/AuthenticationTokenGeneratorService.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/AuthenticationTokenGeneratorService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/AuthenticationTokenService.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/AuthenticationTokenService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/LoginAllowedSecurityService.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/LoginAllowedSecurityService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/StaticAuthenticationService.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/StaticAuthenticationService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/StaticSecurityService.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/StaticSecurityService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/UserDirectoryService.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/UserDirectoryService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/dto/AbstractUserFilter.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/dto/AbstractUserFilter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/dto/AllUserFilter.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/dto/AllUserFilter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/dto/AndUserFilter.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/dto/AndUserFilter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/dto/OrUserFilter.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/dto/OrUserFilter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/dto/RoleUserFilter.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/dto/RoleUserFilter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/dto/UserFilter.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/dto/UserFilter.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/dto/UserFilterVisitor.java
+++ b/plugin/staticsecurity/staticsecurity/src/main/java/org/geomajas/plugin/staticsecurity/security/dto/UserFilterVisitor.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/main/resources/META-INF/geomajasContextStaticSecurity.xml
+++ b/plugin/staticsecurity/staticsecurity/src/main/resources/META-INF/geomajasContextStaticSecurity.xml
@@ -31,7 +31,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2011 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>

--- a/plugin/staticsecurity/staticsecurity/src/main/resources/META-INF/geomajasContextStaticSecurity.xml
+++ b/plugin/staticsecurity/staticsecurity/src/main/resources/META-INF/geomajasContextStaticSecurity.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/command/GetUsersCommandTest.java
+++ b/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/command/GetUsersCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/command/LoginCommandTest.java
+++ b/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/command/LoginCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/command/LogoutCommandTest.java
+++ b/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/command/LogoutCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/AuthenticationServiceTest.java
+++ b/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/AuthenticationServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/CommandDispatcherTest.java
+++ b/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/CommandDispatcherTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/CustomAuthenticationService.java
+++ b/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/CustomAuthenticationService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/GetConfigurationCommandTest.java
+++ b/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/GetConfigurationCommandTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/VectorLayerServiceAttributeTest.java
+++ b/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/VectorLayerServiceAttributeTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/VectorLayerServiceFeatureTest.java
+++ b/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/VectorLayerServiceFeatureTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/VectorLayerServiceInvisibleLayerTest.java
+++ b/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/VectorLayerServiceInvisibleLayerTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/VectorLayerServiceSecurityFilterTest.java
+++ b/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/VectorLayerServiceSecurityFilterTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/VectorLayerServiceVisibleAreaTest.java
+++ b/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/VectorLayerServiceVisibleAreaTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/command/MarinoLoggedIn.java
+++ b/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/general/command/MarinoLoggedIn.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/security/LoginAllowedSecurityServiceTest.java
+++ b/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/security/LoginAllowedSecurityServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/security/StaticSecurityServiceTest.java
+++ b/plugin/staticsecurity/staticsecurity/src/test/java/org/geomajas/plugin/staticsecurity/security/StaticSecurityServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/resources/logback-test.xml
+++ b/plugin/staticsecurity/staticsecurity/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/general/GetConfiguration.xml
+++ b/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/general/GetConfiguration.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/general/VectorLayerSecurityArea.xml
+++ b/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/general/VectorLayerSecurityArea.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/general/VectorLayerSecurityAttribute.xml
+++ b/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/general/VectorLayerSecurityAttribute.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/general/VectorLayerSecurityFeature.xml
+++ b/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/general/VectorLayerSecurityFeature.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/general/VectorLayerSecurityFilter.xml
+++ b/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/general/VectorLayerSecurityFilter.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/general/VectorLayerSecurityInvisibleLayer.xml
+++ b/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/general/VectorLayerSecurityInvisibleLayer.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/general/commandDispatcher.xml
+++ b/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/general/commandDispatcher.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/general/customAuthenticationService.xml
+++ b/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/general/customAuthenticationService.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/security.xml
+++ b/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/security.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/securitywithroles.xml
+++ b/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/securitywithroles.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/userSpecificSecurityForExtract.xml
+++ b/plugin/staticsecurity/staticsecurity/src/test/resources/org/geomajas/plugin/staticsecurity/userSpecificSecurityForExtract.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/vendorspecificpipeline/pom.xml
+++ b/plugin/vendorspecificpipeline/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline-documentation/pom.xml
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline-documentation/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline-documentation/pom.xml
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline-documentation/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-doc-parent</artifactId>
-		<version>2.4.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.plugin</groupId>

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline-documentation/src/docbkx/configuration.xml
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline-documentation/src/docbkx/configuration.xml
@@ -4,7 +4,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline-documentation/src/docbkx/howto.xml
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline-documentation/src/docbkx/howto.xml
@@ -4,7 +4,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline-documentation/src/docbkx/introduction.xml
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline-documentation/src/docbkx/introduction.xml
@@ -4,7 +4,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline-documentation/src/docbkx/master.xml
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline-documentation/src/docbkx/master.xml
@@ -16,7 +16,7 @@
 
 	<bookinfo>
 		<copyright>
-			<year>2011-2015</year>
+			<year>2011-2016</year>
 
 			<holder>Geosparc nv</holder>
 		</copyright>

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline-documentation/src/docbkx/master.xml
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline-documentation/src/docbkx/master.xml
@@ -4,7 +4,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline-javadoc/pom.xml
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline-javadoc/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline/pom.xml
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline/pom.xml
@@ -2,7 +2,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/java/org/geomajas/plugin/vendorspecificpipeline/step/DelaySecurityFilterPostStep.java
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/java/org/geomajas/plugin/vendorspecificpipeline/step/DelaySecurityFilterPostStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/java/org/geomajas/plugin/vendorspecificpipeline/step/DelaySecurityFilterPreStep.java
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/java/org/geomajas/plugin/vendorspecificpipeline/step/DelaySecurityFilterPreStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/java/org/geomajas/plugin/vendorspecificpipeline/step/DelaySecurityFilterStep.java
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/java/org/geomajas/plugin/vendorspecificpipeline/step/DelaySecurityFilterStep.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/resources/META-INF/geomajasContextVendorspecificPipeline.xml
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/resources/META-INF/geomajasContextVendorspecificPipeline.xml
@@ -31,7 +31,7 @@ http://www.springframework.org/schema/util http://www.springframework.org/schema
 			<list>
 				<bean class="org.geomajas.global.CopyrightInfo">
 					<property name="key" value="Geomajas"/>
-					<property name="copyright" value="(c) 2008-2011 Geosparc nv"/>
+					<property name="copyright" value="(c) 2008-2016 Geosparc nv"/>
 					<property name="licenseName" value="GNU Affero General Public License, Version 3"/>
 					<property name="licenseUrl" value="http://www.gnu.org/licenses/agpl-3.0.html"/>
 				</bean>

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/resources/META-INF/geomajasContextVendorspecificPipeline.xml
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/resources/META-INF/geomajasContextVendorspecificPipeline.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/resources/org/geomajas/plugin/vendorspecificpipeline/CachedAndDelaySecurityPipeline.xml
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/resources/org/geomajas/plugin/vendorspecificpipeline/CachedAndDelaySecurityPipeline.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/resources/org/geomajas/plugin/vendorspecificpipeline/DefaultCachedAndDelaySecurityPipelines.xml
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/resources/org/geomajas/plugin/vendorspecificpipeline/DefaultCachedAndDelaySecurityPipelines.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/resources/org/geomajas/plugin/vendorspecificpipeline/DefaultDelaySecurityPipelines.xml
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/resources/org/geomajas/plugin/vendorspecificpipeline/DefaultDelaySecurityPipelines.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/resources/org/geomajas/plugin/vendorspecificpipeline/DelaySecurityPipeline.xml
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline/src/main/resources/org/geomajas/plugin/vendorspecificpipeline/DelaySecurityPipeline.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/plugin/vendorspecificpipeline/vendorspecificpipeline/src/test/resources/logback-test.xml
+++ b/plugin/vendorspecificpipeline/vendorspecificpipeline/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.geomajas</groupId>
 		<artifactId>geomajas-parent</artifactId>
-		<version>2.5.0</version>
+		<version>2.6.1</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.geomajas.project</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/pom.xml
+++ b/testdata/pom.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/java/org/geomajas/testdata/BinaryStreamAssert.java
+++ b/testdata/src/main/java/org/geomajas/testdata/BinaryStreamAssert.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/testdata/src/main/java/org/geomajas/testdata/ClientUserDataObject.java
+++ b/testdata/src/main/java/org/geomajas/testdata/ClientUserDataObject.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/testdata/src/main/java/org/geomajas/testdata/CommandCountAssert.java
+++ b/testdata/src/main/java/org/geomajas/testdata/CommandCountAssert.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/testdata/src/main/java/org/geomajas/testdata/CommandCountService.java
+++ b/testdata/src/main/java/org/geomajas/testdata/CommandCountService.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/testdata/src/main/java/org/geomajas/testdata/CommandCountServiceImpl.java
+++ b/testdata/src/main/java/org/geomajas/testdata/CommandCountServiceImpl.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/testdata/src/main/java/org/geomajas/testdata/Country.java
+++ b/testdata/src/main/java/org/geomajas/testdata/Country.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/testdata/src/main/java/org/geomajas/testdata/LoggingContextLoader.java
+++ b/testdata/src/main/java/org/geomajas/testdata/LoggingContextLoader.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/testdata/src/main/java/org/geomajas/testdata/ReloadContext.java
+++ b/testdata/src/main/java/org/geomajas/testdata/ReloadContext.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/testdata/src/main/java/org/geomajas/testdata/ReloadContextTestExecutionListener.java
+++ b/testdata/src/main/java/org/geomajas/testdata/ReloadContextTestExecutionListener.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/testdata/src/main/java/org/geomajas/testdata/TestPathBinaryStreamAssert.java
+++ b/testdata/src/main/java/org/geomajas/testdata/TestPathBinaryStreamAssert.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/testdata/src/main/java/org/geomajas/testdata/TestPathRenderedImageAssert.java
+++ b/testdata/src/main/java/org/geomajas/testdata/TestPathRenderedImageAssert.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/testdata/src/main/java/org/geomajas/testdata/rule/SecurityRule.java
+++ b/testdata/src/main/java/org/geomajas/testdata/rule/SecurityRule.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/allowAll.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/allowAll.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/beanContext.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/beanContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/clientUserDataContext.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/clientUserDataContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/commandCount8080Context.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/commandCount8080Context.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/commandCount9080Context.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/commandCount9080Context.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/commandCountWebContext.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/commandCountWebContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/layerBeans.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/layerBeans.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/layerBeansMixedGeometry.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/layerBeansMixedGeometry.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/layerBeansMultiLine.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/layerBeansMultiLine.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/layerBeansMultiPolygon.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/layerBeansMultiPolygon.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/layerBeansPoint.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/layerBeansPoint.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/layerBeansSynthetic.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/layerBeansSynthetic.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/layerBluemarble.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/layerBluemarble.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/layerCountries.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/layerCountries.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/layerCountriesStyled.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/layerCountriesStyled.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/layerPopulatedPlaces110m.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/layerPopulatedPlaces110m.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/simplemixedContext.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/simplemixedContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/simplevectorsContext.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/simplevectorsContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/main/resources/org/geomajas/testdata/viewBoundsOptionContext.xml
+++ b/testdata/src/main/resources/org/geomajas/testdata/viewBoundsOptionContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/test/java/org/geomajas/testdata/ReloadBean.java
+++ b/testdata/src/test/java/org/geomajas/testdata/ReloadBean.java
@@ -1,7 +1,7 @@
 /*
  * This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
  *
- * Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+ * Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
  *
  * The program is available in open source according to the GNU Affero
  * General Public License. All contributions in this program are covered

--- a/testdata/src/test/resources/logback-test.xml
+++ b/testdata/src/test/resources/logback-test.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered

--- a/testdata/src/test/resources/org/geomajas/testdata/reloadContext.xml
+++ b/testdata/src/test/resources/org/geomajas/testdata/reloadContext.xml
@@ -1,7 +1,7 @@
 <!--
   ~ This is part of Geomajas, a GIS framework, http://www.geomajas.org/.
   ~
-  ~ Copyright 2008-2015 Geosparc nv, http://www.geosparc.com/, Belgium.
+  ~ Copyright 2008-2016 Geosparc nv, http://www.geosparc.com/, Belgium.
   ~
   ~ The program is available in open source according to the GNU Affero
   ~ General Public License. All contributions in this program are covered


### PR DESCRIPTION
update copyright headers in 3 steps (done in 3 commits):
1) change dependency of geomajas-parent
2) update file headers (checked via checkstyle)
3) change copyright info in some xml files (master.xml files and geomajasContext*.xml files), also from previous years => these files are not checked via checkstyle
=> 3rd step might be debatable, please check commit https://github.com/geomajas/geomajas-project-server/commit/0829587b3acbabfbbd19278d2e97b1b015c1baf1

these changes build via jenkins: see http://ci.geomajas.org/jenkins/job/Geomajas%20Project%20Server%20GBE-572/